### PR TITLE
chore: update stub to exercise PR review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -64,3 +64,4 @@ jobs:
             - If nothing significant is wrong, say so in one sentence and move on
           claude_args: |
             --max-turns 5
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Read,mcp__github_inline_comment__create_inline_comment"

--- a/STUB.txt
+++ b/STUB.txt
@@ -1,1 +1,4 @@
-# This file exists only to trigger PR workflows. Delete after verification.
+# Stub file to exercise GitHub Actions workflows.
+# This is NOT an *.md, docs/**, LICENSE, or .gitignore — so it will
+# trigger the claude-code-review.yml paths filter on pull_request events.
+# Delete after verification.


### PR DESCRIPTION
Touches a non-ignored path (STUB.txt) so the claude-code-review workflow triggers on pull_request events. Files matching *.md, docs/**, LICENSE, and .gitignore are excluded by paths-ignore.

https://claude.ai/code/session_014azN9sqpcMFpfJHNzhUwDD