### PR TITLE
chore: stub to exercise review workflow

### DIFF
--- a/STUB.txt
+++ b/STUB.txt
@@ -2,3 +2,4 @@
 # This is NOT an *.md, docs/**, LICENSE, or .gitignore — so it will
 # trigger the claude-code-review.yml paths filter on pull_request events.
 # Delete after verification.
+# Run 2: exercising updated claude_args with restricted toolset.


### PR DESCRIPTION
Stub change to `STUB.txt` (a non-ignored path) to trigger the `claude-code-review.yml` workflow and verify the restricted `--allowedTools` toolset works correctly.

Delete `STUB.txt` after verification.