### PR TITLE
Remove Tailscale installation from setup script

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -127,7 +127,7 @@ require() {
   fi
 }
 
-TOTAL_STEPS=16
+TOTAL_STEPS=15
 
 # --- Preflight --------------------------------------------------------------
 section "Preflight Checks"
@@ -1160,26 +1160,6 @@ else
   info "Authenticate later with 'gh auth login', then run:"
   info "  cd ~/repos && gh repo list $GITHUB_USER --limit 200 --json name -q '.[].name' | xargs -I{} gh repo clone $GITHUB_USER/{}"
 fi
-
-# --- 16. Tailscale (mesh VPN) ------------------------------------------------
-section "$TOTAL_STEPS/$TOTAL_STEPS — Tailscale (mesh VPN)"
-
-if ! command_exists tailscale; then
-  info "Installing Tailscale..."
-  curl -fsSL https://tailscale.com/install.sh | sh
-fi
-
-if command_exists tailscale; then
-  success "Tailscale installed."
-  if ! tailscale status &>/dev/null; then
-    info "Run 'sudo tailscale up' to authenticate and join your tailnet."
-  else
-    success "Tailscale is connected: $(tailscale ip -4 2>/dev/null || echo '<run tailscale up>')"
-  fi
-else
-  warn "Tailscale install failed. Install manually: https://tailscale.com/download/linux"
-fi
-
 # ============================================================================
 section "🎉 Setup Complete!"
 echo ""
@@ -1192,7 +1172,6 @@ echo "  • Run 'aws configure' (or 'aws configure sso') to set up AWS creds"
 echo "  • Run 'assume <profile>' to switch AWS accounts via Granted"
 echo "  • Set DOCKER_HOST in ~/.bashrc if using a remote Docker daemon"
 echo "  • Run 'claude' to authenticate Claude Code"
-echo "  • Run 'sudo tailscale up' to join your tailnet"
 echo "  • Run 'projects' to see your cloned repos at a glance"
 echo "  • Run 'pull-all' to git pull every repo in ~/repos/"
 echo ""
@@ -1202,7 +1181,6 @@ echo "  Cloud/Ops:    AWS CLI v2, Granted, Terraform, tfswitch, kubectl, eksctl,
 echo "  Containers:   Docker CLI + Compose (no daemon)"
 echo "  Dev tools:    git, gh, VS Code, Claude Code, jq, yq, ripgrep, fzf, bat, tmux"
 echo "  Shell:        Starship prompt, direnv, shellcheck"
-echo "  Networking:   Tailscale (mesh VPN)"
 echo "  Config:       ~/.config/workstation-bootstrap/config (org: ${GITHUB_ORG:-<none>})"
 if [[ -n "${GITHUB_ORG:-}" ]]; then
   echo "  Your code:    ~/repos/ (${GITHUB_USER:-<configure gh>} + ${GITHUB_ORG} repos)"


### PR DESCRIPTION
## Summary
Removes the Tailscale (mesh VPN) installation step from the Crostini lab setup script, reducing the total setup steps from 16 to 15.

## Changes
- Removed the entire "Tailscale (mesh VPN)" installation section (step 16)
- Updated `TOTAL_STEPS` from 16 to 15
- Removed Tailscale-related post-setup instructions from the completion summary:
  - Removed "Run 'sudo tailscale up' to join your tailnet" from next steps
  - Removed "Networking: Tailscale (mesh VPN)" from installed tools list

## Rationale
This change simplifies the setup process by removing an optional networking tool that may not be required for all users. Users who need Tailscale can still install it manually after the initial setup.

https://claude.ai/code/session_019zRSrN2AXuGZTrUv5oMLJe