### PR TITLE
chore: bump crostini script to v4.1 (no tailscale)

### DIFF
--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # ============================================================================
-# setup-crostini-lab.sh — v4 (field-tested on real Chromebook hardware)
+# setup-crostini-lab.sh — v4.1 (field-tested on real Chromebook hardware)
 # Chromebook Crostini (Debian) bootstrap for ops/dev homelab work
 #
 # Author:  Chris Pitzi — PitziLabs (https://github.com/PitziLabs)


### PR DESCRIPTION
## Summary
- Bump crostini script version to v4.1 reflecting tailscale removal
- Stub PR to exercise both CI workflows after `actions/checkout` v4→v6 bump

## Test plan
- [ ] Claude Code Review workflow triggers on this PR
- [ ] Both workflows pass with `actions/checkout@v6`

https://claude.ai/code/session_019zRSrN2AXuGZTrUv5oMLJe