### PR TITLE
Defer Git identity configuration to GitHub auth step

### DIFF
--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -224,38 +224,6 @@ success "Base packages installed."
 # --- 2. Git config ----------------------------------------------------------
 section "2/$TOTAL_STEPS — Git Configuration"
 
-# Try to populate from existing git config first
-[[ -z "$GIT_NAME" ]] && GIT_NAME="$(git config --global user.name 2>/dev/null || true)"
-[[ -z "$GIT_EMAIL" ]] && GIT_EMAIL="$(git config --global user.email 2>/dev/null || true)"
-
-# If still empty and interactive, prompt
-if [[ -z "$GIT_NAME" ]]; then
-  if [[ "$INTERACTIVE" == "true" ]]; then
-    read -rp "Git user.name: " GIT_NAME
-  fi
-fi
-
-if [[ -z "$GIT_EMAIL" ]]; then
-  if [[ "$INTERACTIVE" == "true" ]]; then
-    read -rp "Git user.email: " GIT_EMAIL
-  fi
-fi
-
-# Apply whatever we have (may still be empty — backfilled after gh auth)
-if [[ -n "$GIT_NAME" ]]; then
-  git config --global user.name "$GIT_NAME"
-  info "Set git user.name = $GIT_NAME"
-else
-  info "Git user.name not set yet — will attempt auto-detection after GitHub auth."
-fi
-
-if [[ -n "$GIT_EMAIL" ]]; then
-  git config --global user.email "$GIT_EMAIL"
-  info "Set git user.email = $GIT_EMAIL"
-else
-  info "Git user.email not set yet — will attempt auto-detection after GitHub auth."
-fi
-
 git config --global init.defaultBranch main
 git config --global pull.rebase true
 git config --global push.autoSetupRemote true
@@ -267,7 +235,7 @@ git config --global alias.br "branch"
 git config --global alias.unstage "reset HEAD --"
 git config --global alias.amend "commit --amend --no-edit"
 git config --global alias.wip "!git add -A && git commit -m 'WIP'"
-success "Git configured."
+success "Git defaults configured (identity set after GitHub auth in step 10)."
 
 # --- 3. Python 3 + pip + venv -----------------------------------------------
 section "3/$TOTAL_STEPS — Python 3 + pip + venv"

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -265,35 +265,6 @@ success "Base packages installed."
 # --- 2. Git config ----------------------------------------------------------
 section "2/$TOTAL_STEPS — Git Configuration"
 
-[[ -z "$GIT_NAME" ]] && GIT_NAME="$(git config --global user.name 2>/dev/null || true)"
-[[ -z "$GIT_EMAIL" ]] && GIT_EMAIL="$(git config --global user.email 2>/dev/null || true)"
-
-if [[ -z "$GIT_NAME" ]]; then
-  if [[ "$INTERACTIVE" == "true" ]]; then
-    read -rp "Git user.name: " GIT_NAME
-  fi
-fi
-
-if [[ -z "$GIT_EMAIL" ]]; then
-  if [[ "$INTERACTIVE" == "true" ]]; then
-    read -rp "Git user.email: " GIT_EMAIL
-  fi
-fi
-
-if [[ -n "$GIT_NAME" ]]; then
-  git config --global user.name "$GIT_NAME"
-  info "Set git user.name = $GIT_NAME"
-else
-  info "Git user.name not set yet — will attempt auto-detection after GitHub auth."
-fi
-
-if [[ -n "$GIT_EMAIL" ]]; then
-  git config --global user.email "$GIT_EMAIL"
-  info "Set git user.email = $GIT_EMAIL"
-else
-  info "Git user.email not set yet — will attempt auto-detection after GitHub auth."
-fi
-
 git config --global init.defaultBranch main
 git config --global pull.rebase true
 git config --global push.autoSetupRemote true
@@ -305,7 +276,7 @@ git config --global alias.br "branch"
 git config --global alias.unstage "reset HEAD --"
 git config --global alias.amend "commit --amend --no-edit"
 git config --global alias.wip "!git add -A && git commit -m 'WIP'"
-success "Git configured."
+success "Git defaults configured (identity set after GitHub auth in step 10)."
 
 # --- 3. Python 3 + pip + venv -----------------------------------------------
 section "3/$TOTAL_STEPS — Python 3 + pip + venv"

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -234,35 +234,6 @@ success "Base packages installed."
 # --- 2. Git config ----------------------------------------------------------
 section "2/$TOTAL_STEPS — Git Configuration"
 
-[[ -z "$GIT_NAME" ]] && GIT_NAME="$(git config --global user.name 2>/dev/null || true)"
-[[ -z "$GIT_EMAIL" ]] && GIT_EMAIL="$(git config --global user.email 2>/dev/null || true)"
-
-if [[ -z "$GIT_NAME" ]]; then
-  if [[ "$INTERACTIVE" == "true" ]]; then
-    read -rp "Git user.name: " GIT_NAME
-  fi
-fi
-
-if [[ -z "$GIT_EMAIL" ]]; then
-  if [[ "$INTERACTIVE" == "true" ]]; then
-    read -rp "Git user.email: " GIT_EMAIL
-  fi
-fi
-
-if [[ -n "$GIT_NAME" ]]; then
-  git config --global user.name "$GIT_NAME"
-  info "Set git user.name = $GIT_NAME"
-else
-  info "Git user.name not set yet — will attempt auto-detection after GitHub auth."
-fi
-
-if [[ -n "$GIT_EMAIL" ]]; then
-  git config --global user.email "$GIT_EMAIL"
-  info "Set git user.email = $GIT_EMAIL"
-else
-  info "Git user.email not set yet — will attempt auto-detection after GitHub auth."
-fi
-
 git config --global init.defaultBranch main
 git config --global pull.rebase true
 git config --global push.autoSetupRemote true
@@ -274,7 +245,7 @@ git config --global alias.br "branch"
 git config --global alias.unstage "reset HEAD --"
 git config --global alias.amend "commit --amend --no-edit"
 git config --global alias.wip "!git add -A && git commit -m 'WIP'"
-success "Git configured."
+success "Git defaults configured (identity set after GitHub auth in step 10)."
 
 # --- 3. Python 3 + pip + venv -----------------------------------------------
 section "3/$TOTAL_STEPS — Python 3 + pip + venv"


### PR DESCRIPTION
## Summary
Removed early Git user identity configuration (name and email) from the Git configuration step across all three setup scripts. Git identity is now configured later during the GitHub authentication step (step 10), simplifying the initial setup flow.

## Changes
- **Removed Git identity prompts**: Deleted interactive prompts for `user.name` and `user.email` from step 2 (Git Configuration) in all three setup scripts:
  - `setup-crostini-lab.sh`
  - `setup-fedora-workstation.sh`
  - `setup-xubuntu-workstation.sh`

- **Removed identity fallback logic**: Eliminated code that attempted to populate Git identity from existing global config or prompt users interactively

- **Updated success message**: Changed the completion message from "Git configured." to "Git defaults configured (identity set after GitHub auth in step 10)." to clarify that identity configuration happens later

## Implementation Details
- Git defaults (branch naming, rebase behavior, aliases, etc.) are still configured in step 2
- User identity configuration is deferred to step 10 where GitHub authentication occurs, allowing for potential auto-detection from GitHub account information
- This reduces the number of interactive prompts users encounter early in the setup process

https://claude.ai/code/session_01H9d1K62kxdvjhZPZjFqnd2