### PR TITLE
Add Tailscale to VM variants and update step counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Every script installs the same toolchain:
 | **Containers** | Docker (see variant differences below) |
 | **Dev tools** | VS Code (with extensions + settings), Claude Code, GitHub CLI, git (configured) |
 | **CLI tools** | jq, yq, bat, ripgrep, fd-find, fzf, tree, tmux, shellcheck, direnv, pipx, tldr |
-| **Networking** | dig/nslookup, net-tools, traceroute, nmap, whois |
+| **Networking** | dig/nslookup, net-tools, traceroute, nmap, whois, Tailscale (VM variants only) |
 | **Shell** | Starship prompt (custom config), aliases, functions, direnv |
 | **Your code** | Auto-clones all your GitHub repos into `~/repos/` |
 
@@ -75,7 +75,8 @@ The scripts share ~80% of their code. The differences are driven by what each en
 | **Starship install** | `~/.local/bin` (broken sudo workaround) | `/usr/local/bin` | `/usr/local/bin` |
 | **bat/fd names** | `batcat`/`fdfind` (Debian conflict) | `batcat`/`fdfind` (Ubuntu conflict) | `bat`/`fd` (clean) |
 | **Granted install** | APT repo | APT repo | Binary download (no DNF repo) |
-| **Steps** | 15 | 16 | 16 |
+| **Tailscale** | No | Yes (mesh VPN) | Yes (mesh VPN + firewalld trusted zone) |
+| **Steps** | 15 | 17 | 17 |
 
 ### When to use which
 


### PR DESCRIPTION
## Summary
Updated the README documentation to reflect the addition of Tailscale as a networking tool for VM variants of the installation scripts.

## Key Changes
- Added Tailscale to the networking tools list, noting it's only included in VM variants
- Added a new row to the variant comparison table documenting Tailscale installation differences:
  - Docker variant: No Tailscale
  - Ubuntu variant: Tailscale with mesh VPN
  - Fedora variant: Tailscale with mesh VPN + firewalld trusted zone integration
- Updated step counts to reflect the additional Tailscale installation steps:
  - Docker: remains 15 steps
  - Ubuntu: increased from 16 to 17 steps
  - Fedora: increased from 16 to 17 steps

## Details
This documentation change clarifies that Tailscale is now part of the networking toolchain for VM-based installations, with platform-specific configuration differences between Ubuntu and Fedora variants.

https://claude.ai/code/session_01NwyH3zF9ZUZDpnZGWX7QPe