### PR TITLE
Fix GitHub CLI authentication to properly store credentials

### DIFF
--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -458,7 +458,13 @@ if ! gh auth status &>/dev/null; then
   if [[ -n "${GH_TOKEN:-}" ]]; then
     # Token provided via environment — authenticate non-interactively.
     info "Authenticating GitHub CLI via GH_TOKEN..."
-    echo "$GH_TOKEN" | gh auth login --with-token
+    # Temporarily unset GH_TOKEN so gh can actually store the credentials.
+    # With GH_TOKEN in the environment, gh auth login refuses to write to
+    # the credential store (the env var takes precedence).
+    _SAVED_TOKEN="$GH_TOKEN"
+    unset GH_TOKEN
+    echo "$_SAVED_TOKEN" | gh auth login --with-token
+    unset _SAVED_TOKEN
   else
     # No token — skip. User can run gh auth login manually.
     warn "GitHub CLI is not authenticated."
@@ -503,6 +509,10 @@ if gh auth status &>/dev/null; then
 else
   warn "GitHub auth skipped — repo cloning will only work for public repos."
 fi
+
+# Clear GH_TOKEN — credentials are now stored in gh's credential store.
+# Leaving GH_TOKEN set can interfere with npm, VS Code, and other tools.
+unset GH_TOKEN 2>/dev/null || true
 
 # --- 11. VS Code -------------------------------------------------------------
 section "11/$TOTAL_STEPS — VS Code"

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -505,7 +505,13 @@ success "gh $(gh --version 2>/dev/null | head -1) ready."
 if ! gh auth status &>/dev/null; then
   if [[ -n "${GH_TOKEN:-}" ]]; then
     info "Authenticating GitHub CLI via GH_TOKEN..."
-    echo "$GH_TOKEN" | gh auth login --with-token
+    # Temporarily unset GH_TOKEN so gh can actually store the credentials.
+    # With GH_TOKEN in the environment, gh auth login refuses to write to
+    # the credential store (the env var takes precedence).
+    _SAVED_TOKEN="$GH_TOKEN"
+    unset GH_TOKEN
+    echo "$_SAVED_TOKEN" | gh auth login --with-token
+    unset _SAVED_TOKEN
   else
     warn "GitHub CLI is not authenticated."
     info "Run 'gh auth login' after setup to enable repo cloning."
@@ -545,6 +551,10 @@ if gh auth status &>/dev/null; then
 else
   warn "GitHub auth skipped — repo cloning will only work for public repos."
 fi
+
+# Clear GH_TOKEN — credentials are now stored in gh's credential store.
+# Leaving GH_TOKEN set can interfere with npm, VS Code, and other tools.
+unset GH_TOKEN 2>/dev/null || true
 
 # --- 11. VS Code -------------------------------------------------------------
 section "11/$TOTAL_STEPS — VS Code"

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -450,7 +450,13 @@ success "gh $(gh --version 2>/dev/null | head -1) ready."
 if ! gh auth status &>/dev/null; then
   if [[ -n "${GH_TOKEN:-}" ]]; then
     info "Authenticating GitHub CLI via GH_TOKEN..."
-    echo "$GH_TOKEN" | gh auth login --with-token
+    # Temporarily unset GH_TOKEN so gh can actually store the credentials.
+    # With GH_TOKEN in the environment, gh auth login refuses to write to
+    # the credential store (the env var takes precedence).
+    _SAVED_TOKEN="$GH_TOKEN"
+    unset GH_TOKEN
+    echo "$_SAVED_TOKEN" | gh auth login --with-token
+    unset _SAVED_TOKEN
   else
     warn "GitHub CLI is not authenticated."
     info "Run 'gh auth login' after setup to enable repo cloning."
@@ -490,6 +496,10 @@ if gh auth status &>/dev/null; then
 else
   warn "GitHub auth skipped — repo cloning will only work for public repos."
 fi
+
+# Clear GH_TOKEN — credentials are now stored in gh's credential store.
+# Leaving GH_TOKEN set can interfere with npm, VS Code, and other tools.
+unset GH_TOKEN 2>/dev/null || true
 
 # --- 11. VS Code -------------------------------------------------------------
 section "11/$TOTAL_STEPS — VS Code"


### PR DESCRIPTION
## Summary
Fixed GitHub CLI authentication in setup scripts to properly store credentials in gh's credential store instead of relying on the `GH_TOKEN` environment variable, which can interfere with other tools.

## Key Changes
- **Temporary token unsetting during auth**: Modified the `gh auth login --with-token` flow to temporarily unset `GH_TOKEN` before authentication. This allows gh to properly write credentials to its credential store, as gh refuses to store credentials when the environment variable is already set (the env var takes precedence).
- **Cleanup after authentication**: Added explicit cleanup to unset `GH_TOKEN` after successful authentication in all three setup scripts, preventing the token from interfering with npm, VS Code, and other tools that may read this variable.
- **Applied consistently**: Changes applied to all three setup scripts:
  - `setup-crostini-lab.sh`
  - `setup-fedora-workstation.sh`
  - `setup-xubuntu-workstation.sh`

## Implementation Details
- The token is saved to a temporary variable (`_SAVED_TOKEN`) before unsetting `GH_TOKEN`
- The saved token is then piped to `gh auth login --with-token` for authentication
- The temporary variable is cleaned up immediately after use
- Final cleanup uses `unset GH_TOKEN 2>/dev/null || true` to safely remove the variable without failing if it doesn't exist
- Comments explain the rationale for each step to aid future maintainers

https://claude.ai/code/session_012PCXBXnCkEBpz2hvGNWSyU