### PR TITLE
Refactor SELinux xrdp denial handling for better reliability

### DIFF
--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -1158,12 +1158,14 @@ if command_exists setsebool; then
 
   # Generate a local policy module if audit2allow is available and there are
   # existing denials. This is the "catch whatever we missed" safety net.
-  if command_exists audit2allow && sudo ausearch -m avc -ts recent 2>/dev/null | grep -q xrdp; then
-    info "Generating SELinux policy for existing xrdp denials..."
-    sudo ausearch -m avc -ts recent 2>/dev/null | grep xrdp | \
-      sudo audit2allow -M xrdp-local 2>/dev/null && \
-      sudo semodule -i xrdp-local.pp 2>/dev/null || true
-    rm -f xrdp-local.te xrdp-local.pp xrdp-local.mod 2>/dev/null || true
+  if command_exists audit2allow; then
+    XRDP_DENIALS=$(sudo ausearch -m avc -ts recent 2>/dev/null | grep xrdp 2>/dev/null || true)
+    if [[ -n "$XRDP_DENIALS" ]]; then
+      info "Generating SELinux policy for existing xrdp denials..."
+      echo "$XRDP_DENIALS" | sudo audit2allow -M xrdp-local 2>/dev/null && \
+        sudo semodule -i xrdp-local.pp 2>/dev/null || true
+      rm -f xrdp-local.te xrdp-local.pp xrdp-local.mod 2>/dev/null || true
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Summary
Improved the SELinux policy generation logic for xrdp denials by refactoring the command pipeline to be more robust and maintainable.

## Key Changes
- Separated the audit log search from the denial check by storing results in a variable (`XRDP_DENIALS`)
- Added explicit null/empty check using `[[ -n "$XRDP_DENIALS" ]]` instead of relying on grep's exit status in a pipeline
- Simplified the audit2allow pipeline by piping the stored variable instead of re-running `ausearch` multiple times
- Improved error handling by using `|| true` at the variable assignment level rather than within the pipeline

## Implementation Details
- The refactoring eliminates redundant `ausearch` calls (was called twice in the original code)
- Makes the script more readable by separating concerns: search → check → process
- Maintains the same safety net behavior for catching missed SELinux denials
- Preserves all error suppression and cleanup logic

https://claude.ai/code/session_01VYzmmsSaSpKGYVRU9QMRpt