### PR TITLE
fix: graceful error handling for gh auth + global ERR trap

### DIFF
--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -56,6 +56,12 @@
 
 set -euo pipefail
 
+# --- Global error trap -------------------------------------------------------
+# If set -e kills the script unexpectedly, tell the user what step failed
+# and that re-running is safe (all steps are idempotent).
+CURRENT_STEP="initializing"
+trap 'echo ""; echo -e "${RED}[FATAL] Script failed during: ${CURRENT_STEP}${NC}"; echo -e "${YELLOW}Re-run is safe — completed steps will be skipped (idempotent).${NC}"' ERR
+
 # --- Config (overridable via environment variables) -------------------------
 # These are populated in three stages:
 #   1. Environment variables (if set by the user)
@@ -110,6 +116,7 @@ fail()    { echo -e "${RED}[FAIL]${NC} $*"; exit 1; }
 skip()    { echo -e "${CYAN}[SKIP]${NC} $*"; }
 
 section() {
+  CURRENT_STEP="$*"
   echo ""
   echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
   echo -e "${BOLD}  $*${NC}"
@@ -463,7 +470,14 @@ if ! gh auth status &>/dev/null; then
     # the credential store (the env var takes precedence).
     _SAVED_TOKEN="$GH_TOKEN"
     unset GH_TOKEN
-    echo "$_SAVED_TOKEN" | gh auth login --with-token
+    if echo "$_SAVED_TOKEN" | gh auth login --with-token 2>&1; then
+      : # auth succeeded, continue
+    else
+      warn "GH_TOKEN authentication failed (bad token? expired? wrong scopes?)."
+      info "Continuing without GitHub auth — remaining tools will still install."
+      info "After setup, fix with: gh auth login"
+      info "Or re-run with a valid token: GH_TOKEN=ghp_xxx bash $(basename "$0")"
+    fi
     unset _SAVED_TOKEN
   else
     # No token — skip. User can run gh auth login manually.

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -76,6 +76,12 @@
 
 set -euo pipefail
 
+# --- Global error trap -------------------------------------------------------
+# If set -e kills the script unexpectedly, tell the user what step failed
+# and that re-running is safe (all steps are idempotent).
+CURRENT_STEP="initializing"
+trap 'echo ""; echo -e "${RED}[FATAL] Script failed during: ${CURRENT_STEP}${NC}"; echo -e "${YELLOW}Re-run is safe — completed steps will be skipped (idempotent).${NC}"' ERR
+
 # --- Config (overridable via environment variables) -------------------------
 GITHUB_USER="${GITHUB_USER:-}"
 REPOS_DIR="${REPOS_DIR:-$HOME/repos}"
@@ -122,6 +128,7 @@ fail()    { echo -e "${RED}[FAIL]${NC} $*"; exit 1; }
 skip()    { echo -e "${CYAN}[SKIP]${NC} $*"; }
 
 section() {
+  CURRENT_STEP="$*"
   echo ""
   echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
   echo -e "${BOLD}  $*${NC}"
@@ -510,7 +517,14 @@ if ! gh auth status &>/dev/null; then
     # the credential store (the env var takes precedence).
     _SAVED_TOKEN="$GH_TOKEN"
     unset GH_TOKEN
-    echo "$_SAVED_TOKEN" | gh auth login --with-token
+    if echo "$_SAVED_TOKEN" | gh auth login --with-token 2>&1; then
+      : # auth succeeded, continue
+    else
+      warn "GH_TOKEN authentication failed (bad token? expired? wrong scopes?)."
+      info "Continuing without GitHub auth — remaining tools will still install."
+      info "After setup, fix with: gh auth login"
+      info "Or re-run with a valid token: GH_TOKEN=ghp_xxx bash $(basename "$0")"
+    fi
     unset _SAVED_TOKEN
   else
     warn "GitHub CLI is not authenticated."

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -65,6 +65,12 @@
 
 set -euo pipefail
 
+# --- Global error trap -------------------------------------------------------
+# If set -e kills the script unexpectedly, tell the user what step failed
+# and that re-running is safe (all steps are idempotent).
+CURRENT_STEP="initializing"
+trap 'echo ""; echo -e "${RED}[FATAL] Script failed during: ${CURRENT_STEP}${NC}"; echo -e "${YELLOW}Re-run is safe — completed steps will be skipped (idempotent).${NC}"' ERR
+
 # --- Config (overridable via environment variables) -------------------------
 GITHUB_USER="${GITHUB_USER:-}"
 REPOS_DIR="${REPOS_DIR:-$HOME/repos}"
@@ -107,6 +113,7 @@ fail()    { echo -e "${RED}[FAIL]${NC} $*"; exit 1; }
 skip()    { echo -e "${CYAN}[SKIP]${NC} $*"; }
 
 section() {
+  CURRENT_STEP="$*"
   echo ""
   echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
   echo -e "${BOLD}  $*${NC}"
@@ -455,7 +462,14 @@ if ! gh auth status &>/dev/null; then
     # the credential store (the env var takes precedence).
     _SAVED_TOKEN="$GH_TOKEN"
     unset GH_TOKEN
-    echo "$_SAVED_TOKEN" | gh auth login --with-token
+    if echo "$_SAVED_TOKEN" | gh auth login --with-token 2>&1; then
+      : # auth succeeded, continue
+    else
+      warn "GH_TOKEN authentication failed (bad token? expired? wrong scopes?)."
+      info "Continuing without GitHub auth — remaining tools will still install."
+      info "After setup, fix with: gh auth login"
+      info "Or re-run with a valid token: GH_TOKEN=ghp_xxx bash $(basename "$0")"
+    fi
     unset _SAVED_TOKEN
   else
     warn "GitHub CLI is not authenticated."


### PR DESCRIPTION
## Summary

- Wrap `gh auth login --with-token` in an `if`-block so a bad/expired token degrades to a warning instead of killing the script via `set -e`
- Add a global `ERR` trap after `set -euo pipefail` that reports which step failed on unexpected exit and tells the user re-running is safe
- Track current step automatically via the `section()` function (sets `CURRENT_STEP`) so the ERR trap has context

All three bootstrap scripts updated: `setup-crostini-lab.sh`, `setup-xubuntu-workstation.sh`, `setup-fedora-workstation.sh`.

**Bug fixed:** A bad `GH_TOKEN` previously caused silent script death at step 10, skipping VS Code, Claude Code, shell config, Starship prompt, and repo cloning with no indication of what failed.

## Test plan

- [ ] Run each script with an invalid `GH_TOKEN` — verify warning is printed and script continues through remaining steps
- [ ] Run each script with no `GH_TOKEN` — verify existing behavior unchanged
- [ ] Run each script with a valid `GH_TOKEN` — verify auth succeeds as before
- [ ] Force a failure in a different step — verify ERR trap prints the correct step name
- [ ] Confirm `shellcheck` shows no new warnings (all existing warnings are pre-change)

https://claude.ai/code/session_01QRqEQVv5s5jEcG9vK1aFEy