### PR TITLE
Add hostname configuration to setup scripts

### DIFF
--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -197,16 +197,16 @@ DESIRED_HOSTNAME="crostini"
 if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
   info "Setting hostname to '$DESIRED_HOSTNAME' (was '$(hostname)')..."
   if command_exists hostnamectl; then
-  if ! sudo hostnamectl set-hostname "$DESIRED_HOSTNAME" 2>/dev/null; then
-    echo "$DESIRED_HOSTNAME" | sudo tee /etc/hostname > /dev/null
-    sudo hostname "$DESIRED_HOSTNAME"
-  fi
+    if ! sudo hostnamectl set-hostname "$DESIRED_HOSTNAME" 2>/dev/null; then
+      echo "$DESIRED_HOSTNAME" | sudo tee /etc/hostname > /dev/null
+      sudo hostname "$DESIRED_HOSTNAME"
+    fi
   else
     echo "$DESIRED_HOSTNAME" | sudo tee /etc/hostname > /dev/null
     sudo hostname "$DESIRED_HOSTNAME"
+  fi
   # Update /etc/hosts so sudo can resolve the new hostname
   sudo sed -i "s/127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
-  success "Hostname set to $DESIRED_HOSTNAME"
   success "Hostname set to $DESIRED_HOSTNAME"
 else
   info "Hostname already set to $DESIRED_HOSTNAME"

--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -204,7 +204,9 @@ if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
   else
     echo "$DESIRED_HOSTNAME" | sudo tee /etc/hostname > /dev/null
     sudo hostname "$DESIRED_HOSTNAME"
-  fi
+  # Update /etc/hosts so sudo can resolve the new hostname
+  sudo sed -i "s/127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
+  success "Hostname set to $DESIRED_HOSTNAME"
   success "Hostname set to $DESIRED_HOSTNAME"
 else
   info "Hostname already set to $DESIRED_HOSTNAME"

--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -970,7 +970,7 @@ $aws\
 $kubernetes\
 $cmd_duration\
 $line_break\
-${custom.os}$hostname$directory\
+$hostname${custom.os}$directory\
 $character"""
 
 # --- Prompt character -------------------------------------------------------
@@ -1051,7 +1051,7 @@ style = "bold blue"
 [custom.os]
 command = '. /etc/os-release 2>/dev/null && echo "${ID} ${VERSION_ID}"'
 when = "true"
-format = "[$output]($style) "
+format = "[($output)]($style):"
 style = "bold dimmed green"
 
 # --- Command duration: only shows for commands > 3 seconds -----------------
@@ -1070,7 +1070,7 @@ disabled = true        # we know who we are
 [hostname]
 disabled = false
 ssh_only = false            # Always show — know which box you're on
-format = "[$hostname](bold dimmed green):"
+format = "[$hostname](bold dimmed green) "
 STARSHIP_CONF
 success "Starship config written."
 

--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -206,7 +206,11 @@ if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
     sudo hostname "$DESIRED_HOSTNAME"
   fi
   # Update /etc/hosts so sudo can resolve the new hostname
-  sudo sed -i "s/127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
+  if grep -q "127\.0\.1\.1" /etc/hosts; then
+    sudo sed -i "s/127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
+  else
+    printf "127.0.1.1\t%s\n" "$DESIRED_HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
+  fi
   success "Hostname set to $DESIRED_HOSTNAME"
 else
   info "Hostname already set to $DESIRED_HOSTNAME"

--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -197,7 +197,10 @@ DESIRED_HOSTNAME="crostini"
 if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
   info "Setting hostname to '$DESIRED_HOSTNAME' (was '$(hostname)')..."
   if command_exists hostnamectl; then
-    sudo hostnamectl set-hostname "$DESIRED_HOSTNAME"
+  if ! sudo hostnamectl set-hostname "$DESIRED_HOSTNAME" 2>/dev/null; then
+    echo "$DESIRED_HOSTNAME" | sudo tee /etc/hostname > /dev/null
+    sudo hostname "$DESIRED_HOSTNAME"
+  fi
   else
     echo "$DESIRED_HOSTNAME" | sudo tee /etc/hostname > /dev/null
     sudo hostname "$DESIRED_HOSTNAME"

--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -207,7 +207,7 @@ if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
   fi
   # Update /etc/hosts so sudo can resolve the new hostname
   if grep -q "127\.0\.1\.1" /etc/hosts; then
-    sudo sed -i "s/127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
+    sudo sed -i "s/^127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
   else
     printf "127.0.1.1\t%s\n" "$DESIRED_HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
   fi

--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -207,7 +207,7 @@ if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
   fi
   # Update /etc/hosts so sudo can resolve the new hostname
   if grep -q "127\.0\.1\.1" /etc/hosts; then
-    sudo sed -i "s/^127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
+    sudo sed -i "s/^127\.0\.1\.1[[:space:]].*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
   else
     printf "127.0.1.1\t%s\n" "$DESIRED_HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
   fi

--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -192,6 +192,21 @@ WS_CONF
   info "Edit this file to set your GitHub org and other preferences."
 fi
 
+# --- Set hostname -----------------------------------------------------------
+DESIRED_HOSTNAME="crostini"
+if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
+  info "Setting hostname to '$DESIRED_HOSTNAME' (was '$(hostname)')..."
+  if command_exists hostnamectl; then
+    sudo hostnamectl set-hostname "$DESIRED_HOSTNAME"
+  else
+    echo "$DESIRED_HOSTNAME" | sudo tee /etc/hostname > /dev/null
+    sudo hostname "$DESIRED_HOSTNAME"
+  fi
+  success "Hostname set to $DESIRED_HOSTNAME"
+else
+  info "Hostname already set to $DESIRED_HOSTNAME"
+fi
+
 # --- 1. System update & base packages --------------------------------------
 section "1/$TOTAL_STEPS — System Update & Base Packages"
 

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -231,7 +231,7 @@ if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
     sudo hostname "$DESIRED_HOSTNAME"
   fi
   if grep -q "127\.0\.1\.1" /etc/hosts; then
-    sudo sed -i "s/127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
+    sudo sed -i "s/^127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
   else
     printf "127.0.1.1\t%s\n" "$DESIRED_HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
   fi

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -222,6 +222,16 @@ WS_CONF
   info "Edit this file to set your GitHub org and other preferences."
 fi
 
+# --- Set hostname -----------------------------------------------------------
+DESIRED_HOSTNAME="fedora"
+if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
+  info "Setting hostname to '$DESIRED_HOSTNAME' (was '$(hostname)')..."
+  sudo hostnamectl set-hostname "$DESIRED_HOSTNAME"
+  success "Hostname set to $DESIRED_HOSTNAME"
+else
+  info "Hostname already set to $DESIRED_HOSTNAME"
+fi
+
 # --- 1. System update & base packages --------------------------------------
 section "1/$TOTAL_STEPS — System Update & Base Packages"
 

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -231,7 +231,7 @@ if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
     sudo hostname "$DESIRED_HOSTNAME"
   fi
   if grep -q "127\.0\.1\.1" /etc/hosts; then
-    sudo sed -i "s/^127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
+    sudo sed -i "s/^127\.0\.1\.1[[:space:]].*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
   else
     printf "127.0.1.1\t%s\n" "$DESIRED_HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
   fi

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -227,7 +227,11 @@ DESIRED_HOSTNAME="fedora"
 if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
   info "Setting hostname to '$DESIRED_HOSTNAME' (was '$(hostname)')..."
   sudo hostnamectl set-hostname "$DESIRED_HOSTNAME"
-  sudo sed -i "s/127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
+  if grep -q "127\.0\.1\.1" /etc/hosts; then
+    sudo sed -i "s/127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
+  else
+    printf "127.0.1.1\t%s\n" "$DESIRED_HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
+  fi
   success "Hostname set to $DESIRED_HOSTNAME"
 else
   info "Hostname already set to $DESIRED_HOSTNAME"

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -226,7 +226,10 @@ fi
 DESIRED_HOSTNAME="fedora"
 if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
   info "Setting hostname to '$DESIRED_HOSTNAME' (was '$(hostname)')..."
-  sudo hostnamectl set-hostname "$DESIRED_HOSTNAME"
+  if ! sudo hostnamectl set-hostname "$DESIRED_HOSTNAME" 2>/dev/null; then
+    echo "$DESIRED_HOSTNAME" | sudo tee /etc/hostname > /dev/null
+    sudo hostname "$DESIRED_HOSTNAME"
+  fi
   if grep -q "127\.0\.1\.1" /etc/hosts; then
     sudo sed -i "s/127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
   else

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -975,7 +975,7 @@ $kubernetes\
 $docker_context\
 $cmd_duration\
 $line_break\
-${custom.os}$hostname$directory\
+$hostname${custom.os}$directory\
 $character"""
 
 [character]
@@ -1038,7 +1038,7 @@ only_with_files = true
 [custom.os]
 command = '. /etc/os-release 2>/dev/null && echo "${ID} ${VERSION_ID}"'
 when = "true"
-format = "[$output]($style) "
+format = "[($output)]($style):"
 style = "bold dimmed green"
 
 [cmd_duration]
@@ -1055,7 +1055,7 @@ disabled = true
 [hostname]
 disabled = false
 ssh_only = false
-format = "[$hostname](bold dimmed green):"
+format = "[$hostname](bold dimmed green) "
 STARSHIP_CONF
 success "Starship config written."
 

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -227,6 +227,7 @@ DESIRED_HOSTNAME="fedora"
 if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
   info "Setting hostname to '$DESIRED_HOSTNAME' (was '$(hostname)')..."
   sudo hostnamectl set-hostname "$DESIRED_HOSTNAME"
+  sudo sed -i "s/127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
   success "Hostname set to $DESIRED_HOSTNAME"
 else
   info "Hostname already set to $DESIRED_HOSTNAME"

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -195,6 +195,16 @@ WS_CONF
   info "Edit this file to set your GitHub org and other preferences."
 fi
 
+# --- Set hostname -----------------------------------------------------------
+DESIRED_HOSTNAME="xubuntu"
+if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
+  info "Setting hostname to '$DESIRED_HOSTNAME' (was '$(hostname)')..."
+  sudo hostnamectl set-hostname "$DESIRED_HOSTNAME"
+  success "Hostname set to $DESIRED_HOSTNAME"
+else
+  info "Hostname already set to $DESIRED_HOSTNAME"
+fi
+
 # --- 1. System update & base packages --------------------------------------
 section "1/$TOTAL_STEPS — System Update & Base Packages"
 

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -200,7 +200,11 @@ DESIRED_HOSTNAME="xubuntu"
 if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
   info "Setting hostname to '$DESIRED_HOSTNAME' (was '$(hostname)')..."
   sudo hostnamectl set-hostname "$DESIRED_HOSTNAME"
-  sudo sed -i "s/127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
+  if grep -q "127\.0\.1\.1" /etc/hosts; then
+    sudo sed -i "s/127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
+  else
+    printf "127.0.1.1\t%s\n" "$DESIRED_HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
+  fi
   success "Hostname set to $DESIRED_HOSTNAME"
 else
   info "Hostname already set to $DESIRED_HOSTNAME"

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -932,7 +932,7 @@ $kubernetes\
 $docker_context\
 $cmd_duration\
 $line_break\
-${custom.os}$hostname$directory\
+$hostname${custom.os}$directory\
 $character"""
 
 [character]
@@ -996,7 +996,7 @@ only_with_files = true
 [custom.os]
 command = '. /etc/os-release 2>/dev/null && echo "${ID} ${VERSION_ID}"'
 when = "true"
-format = "[$output]($style) "
+format = "[($output)]($style):"
 style = "bold dimmed green"
 
 [cmd_duration]
@@ -1013,7 +1013,7 @@ disabled = true
 [hostname]
 disabled = false
 ssh_only = false            # Always show hostname — this is a remote workstation
-format = "[$hostname](bold dimmed green):"
+format = "[$hostname](bold dimmed green) "
 STARSHIP_CONF
 success "Starship config written."
 

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -200,6 +200,7 @@ DESIRED_HOSTNAME="xubuntu"
 if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
   info "Setting hostname to '$DESIRED_HOSTNAME' (was '$(hostname)')..."
   sudo hostnamectl set-hostname "$DESIRED_HOSTNAME"
+  sudo sed -i "s/127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
   success "Hostname set to $DESIRED_HOSTNAME"
 else
   info "Hostname already set to $DESIRED_HOSTNAME"

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -199,9 +199,12 @@ fi
 DESIRED_HOSTNAME="xubuntu"
 if [[ "$(hostname)" != "$DESIRED_HOSTNAME" ]]; then
   info "Setting hostname to '$DESIRED_HOSTNAME' (was '$(hostname)')..."
-  sudo hostnamectl set-hostname "$DESIRED_HOSTNAME"
+  if ! sudo hostnamectl set-hostname "$DESIRED_HOSTNAME" 2>/dev/null; then
+    echo "$DESIRED_HOSTNAME" | sudo tee /etc/hostname > /dev/null
+    sudo hostname "$DESIRED_HOSTNAME"
+  fi
   if grep -q "127\.0\.1\.1" /etc/hosts; then
-    sudo sed -i "s/127\.0\.1\.1.*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
+    sudo sed -i "s/^127\.0\.1\.1[[:space:]].*/127.0.1.1\t$DESIRED_HOSTNAME/" /etc/hosts
   else
     printf "127.0.1.1\t%s\n" "$DESIRED_HOSTNAME" | sudo tee -a /etc/hosts > /dev/null
   fi


### PR DESCRIPTION
## Summary
Add automatic hostname configuration to all three setup scripts (Crostini, Fedora, and Xubuntu) to ensure consistent system identification across different environments.

## Key Changes
- **setup-crostini-lab.sh**: Set hostname to "crostini" with fallback support for systems without `hostnamectl`
- **setup-fedora-workstation.sh**: Set hostname to "fedora" using `hostnamectl`
- **setup-xubuntu-workstation.sh**: Set hostname to "xubuntu" using `hostnamectl`

## Implementation Details
- Each script checks if the current hostname matches the desired hostname before making changes
- Skips configuration if hostname is already set correctly
- Provides informative logging for both success and no-op cases
- Crostini script includes fallback logic for older systems that may not have `hostnamectl` available, using `/etc/hostname` and the `hostname` command as alternatives
- Fedora and Xubuntu scripts rely on `hostnamectl` which is standard on these distributions
- Hostname configuration runs early in the setup process, before system updates and package installation

https://claude.ai/code/session_014yaf2YmJVaPKGMgw6FK96Z