### PR TITLE
Fix Granted installation: migrate from dead APT repo to GitHub releases

### DIFF
--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -31,7 +31,7 @@
 #   3.  Python 3 + pip + venv
 #   4.  Node.js (LTS via nvm)
 #   5.  Go (latest stable)
-#   6.  AWS CLI v2 + Granted (account switching via APT)
+#   6.  AWS CLI v2 + Granted (account switching)
 #   7.  Terraform + tfswitch
 #   8.  kubectl + eksctl + Helm
 #   9.  Docker CLI + docker-compose (CLI only, no daemon)
@@ -45,7 +45,7 @@
 # Field-tested bugs fixed in this version:
 #   - nvm: directory must exist before installer; source AFTER install
 #   - nvm: PROFILE=/dev/null to prevent duplicate .bashrc entries
-#   - Granted: use APT repo (GitHub tarball URLs are unstable)
+#   - Granted: binary download from GitHub releases (fwdcloudsec/granted)
 #   - tfswitch: installs to ~/bin; PATH must include it before check
 #   - Starship: install to ~/.local/bin (Crostini sudo is broken for
 #     third-party install scripts); ensure directory exists first
@@ -322,18 +322,26 @@ fi
 require aws "AWS CLI"
 success "AWS CLI $(aws --version 2>&1 | awk '{print $1}') ready."
 
-# [BUG FIX v4] Granted: use official APT repo instead of GitHub release
-# tarballs. The tarball URLs changed and 404'd during field testing.
-# https://docs.commonfate.io/granted/getting-started
+# Granted: repo moved from common-fate/granted to fwdcloudsec/granted after
+# Common Fate wound down. The releases.commonfate.io CDN and APT repo are dead.
+# Download directly from GitHub releases. Granted is MIT-licensed and will keep
+# working, but expect no new releases.
+# Docs: https://docs.commonfate.io/granted/getting-started
 if ! command_exists granted; then
-  info "Installing Granted via APT..."
-  wget -qO- https://apt.releases.commonfate.io/gpg | \
-    sudo gpg --dearmor -o /usr/share/keyrings/common-fate-linux.gpg 2>/dev/null
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/common-fate-linux.gpg] \
-    https://apt.releases.commonfate.io stable main" | \
-    sudo tee /etc/apt/sources.list.d/common-fate.list >/dev/null
-  sudo apt-get update -qq
-  sudo apt-get install -y -qq granted
+  info "Installing Granted..."
+  GRANTED_VERSION=$(curl -fsSL https://api.github.com/repos/fwdcloudsec/granted/releases/latest | \
+    python3 -c 'import sys,json;print(json.load(sys.stdin)["tag_name"].lstrip("v"))' 2>/dev/null) || true
+
+  if [[ -n "${GRANTED_VERSION:-}" ]]; then
+    GRANTED_URL="https://github.com/fwdcloudsec/granted/releases/download/v${GRANTED_VERSION}/granted_${GRANTED_VERSION}_linux_x86_64.tar.gz"
+    curl -fsSL "$GRANTED_URL" -o /tmp/granted.tar.gz
+    tar -xzf /tmp/granted.tar.gz -C /tmp granted assume
+    sudo install -m 0755 /tmp/granted /usr/local/bin/granted
+    sudo install -m 0755 /tmp/assume /usr/local/bin/assume
+    rm -f /tmp/granted.tar.gz /tmp/granted /tmp/assume
+  else
+    warn "Could not determine Granted version. Skipping."
+  fi
 fi
 
 if command_exists granted; then

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -361,20 +361,18 @@ fi
 require aws "AWS CLI"
 success "AWS CLI $(aws --version 2>&1 | awk '{print $1}') ready."
 
-# Granted: no official DNF repo exists. Download the binary from GitHub
-# releases. The Xubuntu version uses APT; the Crostini version uses APT.
-# On Fedora we go direct.
-#
-# NOTE: Common Fate is winding down operations. Granted is MIT-licensed and
-# will continue to work, but expect no new releases.
+# Granted: repo moved from common-fate/granted to fwdcloudsec/granted after
+# Common Fate wound down. The releases.commonfate.io CDN is dead. Download
+# directly from GitHub releases. Granted is MIT-licensed and will keep working,
+# but expect no new releases.
 # Docs: https://docs.commonfate.io/granted/getting-started
 if ! command_exists granted; then
   info "Installing Granted..."
-  GRANTED_VERSION=$(curl -fsSL https://api.github.com/repos/common-fate/granted/releases/latest | \
+  GRANTED_VERSION=$(curl -fsSL https://api.github.com/repos/fwdcloudsec/granted/releases/latest | \
     python3 -c 'import sys,json;print(json.load(sys.stdin)["tag_name"].lstrip("v"))' 2>/dev/null) || true
 
   if [[ -n "${GRANTED_VERSION:-}" ]]; then
-    GRANTED_URL="https://releases.commonfate.io/granted/v${GRANTED_VERSION}/granted_${GRANTED_VERSION}_linux_x86_64.tar.gz"
+    GRANTED_URL="https://github.com/fwdcloudsec/granted/releases/download/v${GRANTED_VERSION}/granted_${GRANTED_VERSION}_linux_x86_64.tar.gz"
     curl -fsSL "$GRANTED_URL" -o /tmp/granted.tar.gz
     tar -xzf /tmp/granted.tar.gz -C /tmp granted assume
     sudo install -m 0755 /tmp/granted /usr/local/bin/granted

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -364,6 +364,10 @@ success "AWS CLI $(aws --version 2>&1 | awk '{print $1}') ready."
 # Granted: no official DNF repo exists. Download the binary from GitHub
 # releases. The Xubuntu version uses APT; the Crostini version uses APT.
 # On Fedora we go direct.
+#
+# NOTE: Common Fate is winding down operations. Granted is MIT-licensed and
+# will continue to work, but expect no new releases.
+# Docs: https://docs.commonfate.io/granted/getting-started
 if ! command_exists granted; then
   info "Installing Granted..."
   GRANTED_VERSION=$(curl -fsSL https://api.github.com/repos/common-fate/granted/releases/latest | \

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -40,7 +40,7 @@
 #   3.  Python 3 + pip + venv
 #   4.  Node.js (LTS via nvm)
 #   5.  Go (latest stable)
-#   6.  AWS CLI v2 + Granted (account switching via APT)
+#   6.  AWS CLI v2 + Granted (account switching)
 #   7.  Terraform + tfswitch
 #   8.  kubectl + eksctl + Helm
 #   9.  Docker Engine + docker-compose (full daemon)
@@ -326,15 +326,26 @@ fi
 require aws "AWS CLI"
 success "AWS CLI $(aws --version 2>&1 | awk '{print $1}') ready."
 
+# Granted: repo moved from common-fate/granted to fwdcloudsec/granted after
+# Common Fate wound down. The releases.commonfate.io CDN and APT repo are dead.
+# Download directly from GitHub releases. Granted is MIT-licensed and will keep
+# working, but expect no new releases.
+# Docs: https://docs.commonfate.io/granted/getting-started
 if ! command_exists granted; then
-  info "Installing Granted via APT..."
-  wget -qO- https://apt.releases.commonfate.io/gpg | \
-    sudo gpg --dearmor -o /usr/share/keyrings/common-fate-linux.gpg 2>/dev/null
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/common-fate-linux.gpg] \
-    https://apt.releases.commonfate.io stable main" | \
-    sudo tee /etc/apt/sources.list.d/common-fate.list >/dev/null
-  sudo apt-get update -qq
-  sudo apt-get install -y -qq granted
+  info "Installing Granted..."
+  GRANTED_VERSION=$(curl -fsSL https://api.github.com/repos/fwdcloudsec/granted/releases/latest | \
+    python3 -c 'import sys,json;print(json.load(sys.stdin)["tag_name"].lstrip("v"))' 2>/dev/null) || true
+
+  if [[ -n "${GRANTED_VERSION:-}" ]]; then
+    GRANTED_URL="https://github.com/fwdcloudsec/granted/releases/download/v${GRANTED_VERSION}/granted_${GRANTED_VERSION}_linux_x86_64.tar.gz"
+    curl -fsSL "$GRANTED_URL" -o /tmp/granted.tar.gz
+    tar -xzf /tmp/granted.tar.gz -C /tmp granted assume
+    sudo install -m 0755 /tmp/granted /usr/local/bin/granted
+    sudo install -m 0755 /tmp/assume /usr/local/bin/assume
+    rm -f /tmp/granted.tar.gz /tmp/granted /tmp/assume
+  else
+    warn "Could not determine Granted version. Skipping."
+  fi
 fi
 
 if command_exists granted; then


### PR DESCRIPTION
## Summary
Updates all three setup scripts to install Granted directly from GitHub releases instead of relying on the defunct `releases.commonfate.io` APT repository and CDN. This addresses the repository migration from `common-fate/granted` to `fwdcloudsec/granted` after Common Fate wound down operations.

## Key Changes
- **setup-crostini-lab.sh**: Replaced APT-based installation with direct GitHub release binary download
- **setup-xubuntu-workstation.sh**: Replaced APT-based installation with direct GitHub release binary download
- **setup-fedora-workstation.sh**: Updated GitHub repository URL from `common-fate/granted` to `fwdcloudsec/granted` and changed download source from `releases.commonfate.io` CDN to GitHub releases
- Updated documentation comments in all scripts to reflect the repository migration and explain the rationale for the new installation method

## Implementation Details
- All three scripts now use a consistent approach: fetch the latest release version from the GitHub API, construct the download URL for the Linux x86_64 tarball, extract the binaries, and install them to `/usr/local/bin`
- Added error handling with a fallback warning if the version cannot be determined from the GitHub API
- Cleaned up temporary files after installation
- Updated inline documentation to note that Granted is MIT-licensed and will continue to work despite no new releases being expected

https://claude.ai/code/session_0182fC461gVzTrMV6eiQ5Pqg