### PR TITLE
Migrate workflows to PitziLabs/shared-workflows reusable templates

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,15 +1,8 @@
 # ============================================================================
 # Claude Code — Automated PR Review
 # ============================================================================
-# Runs automatically on every PR. No plugins, no marketplace — just a focused
-# review prompt with the PR context the action provides natively.
-#
-# The action already knows the PR context (repo, number, diff, branch) when
-# triggered by pull_request events. We just need to tell it what to focus on.
-#
-# The reviewer is read-only by design: it reads the diff and source files,
-# then returns a single consolidated review. The action posts the result.
-# No incremental commenting — one pass, one artifact.
+# Thin wrapper around PitziLabs/shared-workflows/claude-review.yml.
+# Pinned to Haiku.
 # ============================================================================
 
 name: Claude Code Review
@@ -25,55 +18,17 @@ on:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
+    uses: PitziLabs/shared-workflows/.github/workflows/claude-review.yml@main
+    secrets: inherit
+    with:
+      review_prompt: |
+        This repository contains bash bootstrap scripts for Linux workstations
+        and Terraform infrastructure code. Focus your review on:
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-
-            Review this pull request. The PR branch is already checked out.
-
-            This repository contains bash bootstrap scripts for Linux workstations
-            and Terraform infrastructure code. Focus your review on:
-
-            1. **Bash correctness** — quoting bugs, unset variable references,
-               broken conditionals, incorrect exit codes, non-portable syntax
-            2. **Idempotency** — will re-running the script break anything?
-            3. **Security** — hardcoded credentials, secrets in output, unsafe
-               permissions, curl|bash pitfalls
-            4. **Terraform** — if HCL files changed: dependency graph issues,
-               resources requiring multiple applies, missing variable validation
-
-            Rules:
-            - Only comment on actual problems or meaningful improvements
-            - Do NOT comment on style, formatting, or naming preferences
-            - Do NOT give positive feedback or praise — just flag issues
-            - Do NOT propose inline fix code — describe the problem and why it
-              matters, not the solution. Fixes go through a separate commit.
-            - If nothing significant is wrong, say so in one sentence and move on
-
-            Output format:
-            - Read the full diff and any source files needed for context
-            - Collect ALL findings before producing any output
-            - Return a single consolidated review — do not post comments
-              incrementally as you discover issues
-          claude_args: |
-            --max-turns 15
-            --model haiku
-            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Read"
+        1. **Bash correctness** — quoting bugs, unset variable references,
+           broken conditionals, incorrect exit codes, non-portable syntax
+        2. **Idempotency** — will re-running the script break anything?
+        3. **Security** — hardcoded credentials, secrets in output, unsafe
+           permissions, curl|bash pitfalls
+        4. **Terraform** — if HCL files changed: dependency graph issues,
+           resources requiring multiple applies, missing variable validation

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,15 +1,7 @@
 # ============================================================================
 # Claude Code — Interactive @claude Responder
 # ============================================================================
-# Responds when someone tags @claude in an issue or PR comment/review.
-# This is the interactive assistant — it does whatever is asked in the comment.
-#
-# When triggered from an issue, Claude Code reads the repo, implements the
-# requested changes, creates a PR, and enables auto-merge. The PR must pass
-# ShellCheck and Claude Code Review before it merges.
-#
-# This workflow only fires on explicit @claude mentions, so runtime is less
-# of a concern (the user is waiting for a response to a specific question).
+# Thin wrapper around PitziLabs/shared-workflows/claude-responder.yml.
 # ============================================================================
 
 name: Claude Code
@@ -28,38 +20,7 @@ on:
 
 jobs:
   claude:
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code
-        uses: anthropics/claude-code-action@v1
-        env:
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: "64000"
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
-            --max-turns 25
-            --model ${{
-              (contains(github.event.issue.labels.*.name, 'model:opus') ||
-               contains(github.event.pull_request.labels.*.name, 'model:opus')) && 'opus' ||
-              (contains(github.event.issue.labels.*.name, 'model:haiku') ||
-               contains(github.event.pull_request.labels.*.name, 'model:haiku')) && 'haiku' ||
-              'sonnet'
-            }}
-            --allowedTools "Bash" "Read" "Edit" "Write" "Glob" "Grep"
+    uses: PitziLabs/shared-workflows/.github/workflows/claude-responder.yml@main
+    secrets: inherit
+    with:
+      allowed_tools: '"Bash" "Read" "Edit" "Write" "Glob" "Grep"'

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,12 +1,8 @@
 # ============================================================================
-# ShellCheck — Static Analysis for Bootstrap Scripts
+# ShellCheck — Static Analysis
 # ============================================================================
-# Runs ShellCheck against all three bootstrap scripts on every PR.
-# This is the first automated quality gate — catches quoting bugs, unset
-# variable references, non-portable syntax, and common bash pitfalls before
-# Claude Code Review even looks at the diff.
-#
-# Designed as a required status check for branch protection / auto-merge.
+# Thin wrapper around PitziLabs/shared-workflows/shellcheck.yml.
+# Required status check for branch protection / auto-merge.
 # ============================================================================
 
 name: ShellCheck
@@ -17,50 +13,9 @@ on:
 
 jobs:
   shellcheck:
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
-      - name: Run ShellCheck
-        run: |
-          # Install latest ShellCheck (ubuntu-latest ships an older version)
-          sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
-
-          echo "ShellCheck version: $(shellcheck --version | head -2 | tail -1)"
-          echo ""
-
-          SCRIPTS=(
-            setup-crostini-lab.sh
-            setup-xubuntu-workstation.sh
-            setup-fedora-workstation.sh
-          )
-
-          FAILED=0
-          for script in "${SCRIPTS[@]}"; do
-            if [[ -f "$script" ]]; then
-              echo "━━━ Checking $script ━━━"
-              if shellcheck --severity=warning --shell=bash "$script"; then
-                echo "✓ $script passed"
-              else
-                FAILED=1
-                echo "✗ $script has issues"
-              fi
-              echo ""
-            else
-              echo "⚠ $script not found (skipping)"
-            fi
-          done
-
-          if [[ "$FAILED" -eq 1 ]]; then
-            echo "::error::ShellCheck found issues in one or more scripts."
-            exit 1
-          fi
-
-          echo "All scripts passed ShellCheck."
+    uses: PitziLabs/shared-workflows/.github/workflows/shellcheck.yml@main
+    with:
+      scripts: |
+        setup-crostini-lab.sh
+        setup-xubuntu-workstation.sh
+        setup-fedora-workstation.sh


### PR DESCRIPTION
Replace the in-line claude.yml, claude-code-review.yml, and (where present) shellcheck.yml with thin wrappers that delegate to the reusable workflows in PitziLabs/shared-workflows. Repo-specific configuration (allowed_tools, default_model, review focus block, script list) becomes input parameters; everything else moves into the shared templates.

Net effect: the workflows directory shrinks by ~70%, and future changes to the responder predicate, model routing, output cap, or review scaffolding land in one place across all consumer repos.