### PR TITLE
Grant required permissions on reusable workflow callers

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,11 @@ on:
 
 jobs:
   claude-review:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
     uses: PitziLabs/shared-workflows/.github/workflows/claude-review.yml@main
     secrets: inherit
     with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,6 +20,12 @@ on:
 
 jobs:
   claude:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
     uses: PitziLabs/shared-workflows/.github/workflows/claude-responder.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary
- Add `permissions:` blocks to the `claude` and `claude-review` jobs that call the shared reusable workflows. Reusable workflows can only inherit caller permissions, never elevate them — without these blocks, every responder/review run fails with `startup_failure` and the message "is requesting X but is only allowed Y".

## Why
- The shared workflows in `PitziLabs/shared-workflows` declare the permissions they need (contents: write, pull-requests: write, etc.). When the caller doesn't grant at least those, GitHub rejects the workflow at parse time.
- Verified via the smoke-test issue on PitziLabs/homeassistant-config — the run failed with the exact mismatch this PR fixes.

## Test plan
- [ ] On merge, open a trivial issue with `@claude` mention and a `model:haiku` label; confirm the responder workflow runs (no startup_failure) and routes to Haiku.
- [ ] On a follow-up PR, confirm the review workflow runs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)