### PR TITLE
Add setup-ubuntu-laptop.sh for bare-metal Ubuntu Desktop

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -19,3 +19,4 @@ jobs:
         setup-crostini-lab.sh
         setup-xubuntu-workstation.sh
         setup-fedora-workstation.sh
+        setup-ubuntu-laptop.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Three standalone bash scripts that bootstrap a fresh Linux environment into a fu
 | `setup-crostini-lab.sh` | Chromebook Crostini (Debian) | apt-get |
 | `setup-xubuntu-workstation.sh` | Xubuntu 24.04 LTS VM | apt-get |
 | `setup-fedora-workstation.sh` | Fedora KDE Plasma VM | dnf |
+| `setup-ubuntu-laptop.sh` | Ubuntu Desktop LTS (bare-metal laptop) | apt-get |
 
 ## There is no build/test/lint system
 
@@ -30,10 +31,11 @@ Key platform differences to keep in mind when editing:
 - **Crostini**: CLI-only Docker (no daemon), installs to `~/.local/bin` (broken sudo), `batcat`/`fdfind` naming
 - **Xubuntu**: Full Docker Engine, XRDP+XFCE, `batcat`/`fdfind` naming
 - **Fedora**: Full Docker Engine (removes podman first), XRDP+KDE Plasma X11, SELinux policy, firewalld rules, JavaScript polkit rules, `bat`/`fd` clean names, Granted installed via binary (no DNF repo)
+- **Ubuntu laptop**: Full Docker Engine, no XRDP, TLP replaces power-profiles-daemon, ThinkPad charge thresholds (75-80%), fwupd timer enabled, `batcat`/`fdfind` naming
 
 ## Editing guidelines
 
-- **All three scripts must stay in sync** for shared functionality. If you change how a tool is installed or configured in one script, apply the same change to the others (adapting for the package manager and platform).
+- **All four scripts must stay in sync** for shared functionality across the apt-based variants and adapted for Fedora's package manager. If you change how a tool is installed or configured in one script, apply the same change to the others (adapting for the package manager and platform).
 - **Every step must be idempotent.** Always check if something is already installed before installing it. Re-running the script must be safe.
 - **The `set -e` arithmetic trap**: `((count++))` returns exit code 1 when count is 0. Always use `((count++)) || true`.
 - **PATH bootstrapping**: Tools installed mid-script must be findable during the script. PATH is set at the top, not deferred to `.bashrc`.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ workstation-bootstrap/
 ├── setup-crostini-lab.sh          # Chromebook Crostini (Debian container)
 ├── setup-xubuntu-workstation.sh   # Xubuntu 24.04 LTS VM (Proxmox)
 ├── setup-fedora-workstation.sh    # Fedora KDE Plasma VM (Proxmox)
+├── setup-ubuntu-laptop.sh         # Ubuntu Desktop LTS on bare-metal laptop
 ├── README.md
 └── LICENSE
 ```
@@ -37,6 +38,12 @@ curl -sLO https://raw.githubusercontent.com/PitziLabs/workstation-bootstrap/main
 GH_TOKEN=ghp_yourtoken bash setup-fedora-workstation.sh
 ```
 
+**Ubuntu Desktop laptop (bare metal):**
+```bash
+curl -sLO https://raw.githubusercontent.com/PitziLabs/workstation-bootstrap/main/setup-ubuntu-laptop.sh
+GH_TOKEN=ghp_yourtoken bash setup-ubuntu-laptop.sh
+```
+
 Omit `GH_TOKEN=...` for interactive runs — the script will prompt you to authenticate via `gh auth login`.
 
 > **Why download first?** The `curl | bash` pattern sets `GH_TOKEN` for the `bash` process (not `curl`), but stdin is consumed by the pipe so interactive prompts won't work. Downloading first avoids both issues.
@@ -60,29 +67,33 @@ Every script installs the same toolchain:
 
 The scripts share ~80% of their code. The differences are driven by what each environment can and can't do.
 
-| Area | Crostini | Xubuntu VM | Fedora KDE VM |
-|---|---|---|---|
-| **Package manager** | `apt-get` (Debian) | `apt-get` (Ubuntu) | `dnf` (Fedora RPM) |
-| **Docker** | CLI-only (no daemon) | Full engine + daemon | Full engine + daemon (replaces podman) |
-| **Remote desktop** | N/A (local terminal) | XRDP + XFCE | XRDP + KDE Plasma X11 |
-| **SSH server** | No | Yes | Yes |
-| **SELinux** | No | No | Enforcing (xrdp policy configured) |
-| **Firewall** | None | None (ufw not default) | firewalld (port 3389 opened) |
-| **Polkit rules** | N/A | `.pkla` format | JavaScript `.rules` format |
-| **Compositor fix** | N/A | xfwm4 XML | KWin `kwinrc` |
-| **Wayland** | N/A | N/A (X11 default) | Forced to X11 for XRDP |
-| **VM integration** | N/A | qemu-guest-agent | qemu-guest-agent |
-| **Starship install** | `~/.local/bin` (broken sudo workaround) | `/usr/local/bin` | `/usr/local/bin` |
-| **bat/fd names** | `batcat`/`fdfind` (Debian conflict) | `batcat`/`fdfind` (Ubuntu conflict) | `bat`/`fd` (clean) |
-| **Granted install** | APT repo | APT repo | Binary download (no DNF repo) |
-| **Tailscale** | No | Yes (mesh VPN) | Yes (mesh VPN + firewalld trusted zone) |
-| **Steps** | 14 | 16 | 16 |
+| Area | Crostini | Xubuntu VM | Fedora KDE VM | Ubuntu laptop |
+|---|---|---|---|---|
+| **Package manager** | `apt-get` (Debian) | `apt-get` (Ubuntu) | `dnf` (Fedora RPM) | `apt-get` (Ubuntu) |
+| **Docker** | CLI-only (no daemon) | Full engine + daemon | Full engine + daemon (replaces podman) | Full engine + daemon |
+| **Remote desktop** | N/A (local terminal) | XRDP + XFCE | XRDP + KDE Plasma X11 | N/A (local GNOME) |
+| **SSH server** | No | Yes | Yes | Yes |
+| **SELinux** | No | No | Enforcing (xrdp policy configured) | No |
+| **Firewall** | None | None (ufw not default) | firewalld (port 3389 opened) | None (ufw not default) |
+| **Polkit rules** | N/A | `.pkla` format | JavaScript `.rules` format | N/A |
+| **Compositor fix** | N/A | xfwm4 XML | KWin `kwinrc` | N/A |
+| **Wayland** | N/A | N/A (X11 default) | Forced to X11 for XRDP | Default (GNOME local) |
+| **VM integration** | N/A | qemu-guest-agent | qemu-guest-agent | N/A (bare metal) |
+| **Power management** | N/A | N/A | N/A | TLP (replaces power-profiles-daemon) |
+| **Firmware updates** | N/A | N/A | N/A | fwupd (LVFS) |
+| **Battery thresholds** | N/A | N/A | N/A | ThinkPad: 75-80% (configurable) |
+| **Starship install** | `~/.local/bin` (broken sudo workaround) | `/usr/local/bin` | `/usr/local/bin` | `/usr/local/bin` |
+| **bat/fd names** | `batcat`/`fdfind` (Debian conflict) | `batcat`/`fdfind` (Ubuntu conflict) | `bat`/`fd` (clean) | `batcat`/`fdfind` (Ubuntu conflict) |
+| **Granted install** | APT repo | APT repo | Binary download (no DNF repo) | APT repo |
+| **Tailscale** | No | Yes (mesh VPN) | Yes (mesh VPN + firewalld trusted zone) | Yes (mesh VPN) |
+| **Steps** | 14 | 16 | 16 | 16 |
 
 ### When to use which
 
 - **Crostini** — You're on a Chromebook and want a local dev environment. Lightweight, disposable, no Docker daemon (point `DOCKER_HOST` at a remote). Start here.
 - **Xubuntu** — You have a Proxmox host (or any hypervisor) and want a persistent workhorse VM with full Docker. XFCE is lighter on resources. Good default.
 - **Fedora KDE** — You want KDE Plasma's desktop, Fedora's fresh packages, and SELinux enforcing by default. Slightly heavier, more opinionated, better desktop experience for power users.
+- **Ubuntu laptop** — You're sitting in front of a real laptop (developed against a refurbished ThinkPad T14, but works for any Ubuntu Desktop machine). Same toolchain as Xubuntu, no XRDP/QEMU agent, plus TLP for battery thresholds and fwupd for firmware updates. Use this for bare metal; use Xubuntu/Fedora for VMs.
 
 ## Why this exists
 
@@ -245,6 +256,11 @@ The workstation config file at `~/.config/workstation-bootstrap/config` is never
 - Proxmox VE host (or any hypervisor)
 - Fedora KDE Plasma installed as a VM (KDE Spin ISO or Fedora Everything + KDE group)
 - At least 2 vCPUs, 8 GiB RAM, 50 GiB disk recommended
+
+**Ubuntu Desktop laptop:**
+- Any laptop running Ubuntu Desktop 24.04 LTS or newer
+- ThinkPad recommended for charge-threshold support (script auto-detects and skips on unsupported hardware)
+- ~10 minutes and an internet connection
 
 ## Credits
 

--- a/setup-ubuntu-laptop.sh
+++ b/setup-ubuntu-laptop.sh
@@ -1,0 +1,1266 @@
+#!/usr/bin/env bash
+# ============================================================================
+# setup-ubuntu-laptop.sh — v1 (adapted from setup-xubuntu-workstation.sh)
+# Ubuntu Desktop LTS on bare-metal laptop — DevOps workstation bootstrap
+#
+# Author:  Chris Pitzi — PitziLabs (https://github.com/PitziLabs)
+# Updated: 2026-04-28
+#
+# Lineage: Forked from setup-xubuntu-workstation.sh v1, which was forked from
+#          setup-crostini-lab.sh v4. The Xubuntu version targets a Proxmox VM
+#          accessed via XRDP from a Chromebook. This version targets a
+#          bare-metal Ubuntu Desktop laptop (developed against a refurbished
+#          Lenovo ThinkPad T14) where the user sits in front of the machine
+#          locally. Differences:
+#            - No XRDP (you're using GNOME/Unity locally)
+#            - No qemu-guest-agent (not a VM)
+#            - Adds TLP for battery management + ThinkPad charge thresholds
+#            - Adds fwupd for LVFS firmware updates (microcode, EC, Thunderbolt)
+#            - Removes power-profiles-daemon (conflicts with TLP)
+#            - Keeps openssh-server so the laptop is reachable from the
+#              Chromebook on the tailnet
+#
+# Usage:
+#   Quick start (download first — recommended):
+#     curl -sLO https://raw.githubusercontent.com/PitziLabs/workstation-bootstrap/main/setup-ubuntu-laptop.sh
+#     GH_TOKEN=ghp_yourtoken bash setup-ubuntu-laptop.sh
+#
+#   Or pipe directly (note: GH_TOKEN goes AFTER the pipe):
+#     curl -sL https://raw.githubusercontent.com/PitziLabs/workstation-bootstrap/main/setup-ubuntu-laptop.sh | GH_TOKEN=ghp_yourtoken bash
+#
+# Environment variables (all optional — auto-detected when possible):
+#   GH_TOKEN        GitHub personal access token (scopes: repo, read:org)
+#                   If set, skips interactive gh auth login entirely.
+#   GIT_NAME        Git user.name (auto-detected from gh profile or prompted)
+#   GIT_EMAIL       Git user.email (auto-detected from gh profile or prompted)
+#   GITHUB_USER     GitHub username for repo cloning (auto-detected from gh auth)
+#   REPOS_DIR       Where to clone repos (default: ~/repos)
+#
+# IMPORTANT: Run with 'bash', not 'sh'. Ubuntu's sh is dash, not bash.
+#            The shebang handles this if you chmod +x and use ./
+#
+# What this does:
+#   1.  System basics & quality-of-life CLI tools
+#   2.  Git config (interactive)
+#   3.  Python 3 + pip + venv
+#   4.  Node.js (LTS via nvm)
+#   5.  Go (latest stable)
+#   6.  AWS CLI v2 + Granted (account switching)
+#   7.  Terraform + tfswitch
+#   8.  kubectl + eksctl + Helm
+#   9.  Docker Engine + docker-compose (full daemon)
+#  10.  GitHub CLI (gh) + authenticate + clone repos
+#  11.  VS Code (via Microsoft APT repo)
+#  12.  Claude Code
+#  13.  Quality-of-life CLI tools
+#  14.  Shell config (starship prompt, aliases, PATH wiring)
+#  15.  Laptop power management (TLP) + firmware updates (fwupd)
+#  16.  Tailscale (mesh VPN)
+#
+# Changes from Xubuntu version:
+#   - Removed: XRDP step entirely (step 15 in xubuntu)
+#   - Removed: qemu-guest-agent from base packages
+#   - Removed: XFCE compositor config, startwm.sh override, colord pkla
+#   - Removed: "Take a Proxmox snapshot" from post-install checklist
+#   - Added: TLP + tlp-rdw with ThinkPad charge thresholds (step 15)
+#   - Added: fwupd with refresh timer enabled (step 15)
+#   - Added: Removal of power-profiles-daemon (conflicts with TLP)
+#   - Modified: Marker migration loop now also handles xubuntu/fedora markers
+#   - Modified: Starship config docker_context module retained as-is
+# ============================================================================
+
+set -euo pipefail
+
+# --- Global error trap -------------------------------------------------------
+# If set -e kills the script unexpectedly, tell the user what step failed
+# and that re-running is safe (all steps are idempotent).
+CURRENT_STEP="initializing"
+trap 'echo ""; echo -e "${RED}[FATAL] Script failed during: ${CURRENT_STEP}${NC}"; echo -e "${YELLOW}Re-run is safe — completed steps will be skipped (idempotent).${NC}"' ERR
+
+# --- Config (overridable via environment variables) -------------------------
+GITHUB_USER="${GITHUB_USER:-}"
+REPOS_DIR="${REPOS_DIR:-$HOME/repos}"
+GIT_NAME="${GIT_NAME:-}"
+GIT_EMAIL="${GIT_EMAIL:-}"
+
+# --- Workstation config (personal overrides) --------------------------------
+# Source user config if it exists. This lets you set GITHUB_ORG,
+# GITHUB_DEFAULT_OWNER, and future preferences without editing the script.
+WS_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/workstation-bootstrap/config"
+GITHUB_ORG="${GITHUB_ORG:-}"
+GITHUB_DEFAULT_OWNER="${GITHUB_DEFAULT_OWNER:-}"
+
+if [[ -f "$WS_CONFIG" ]]; then
+  # shellcheck source=/dev/null
+  . "$WS_CONFIG"
+fi
+
+# Detect whether stdin is a terminal (interactive) or piped (automated)
+INTERACTIVE=false
+[[ -t 0 ]] && INTERACTIVE=true
+
+# --- Bootstrap PATH early ---------------------------------------------------
+mkdir -p "$HOME/.local/bin" "$HOME/bin"
+export PATH="$HOME/.local/bin:$HOME/bin:$HOME/go/bin:/usr/local/go/bin:$PATH"
+
+# --- Colors & helpers -------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}[INFO]${NC} $*"; }
+success() { echo -e "${GREEN}[ OK ]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $*"; }
+fail()    { echo -e "${RED}[FAIL]${NC} $*"; exit 1; }
+skip()    { echo -e "${CYAN}[SKIP]${NC} $*"; }
+
+section() {
+  CURRENT_STEP="$*"
+  echo ""
+  echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo -e "${BOLD}  $*${NC}"
+  echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+}
+
+command_exists() { command -v "$1" &>/dev/null; }
+
+require() {
+  local cmd="$1"
+  local friendly="${2:-$1}"
+  if ! command_exists "$cmd"; then
+    fail "$friendly failed to install. Check the output above for errors."
+  fi
+}
+
+TOTAL_STEPS=16
+
+# --- Preflight --------------------------------------------------------------
+section "Preflight Checks"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  fail "This script is for Linux. You're on $(uname -s)."
+fi
+
+if [[ -z "${BASH_VERSION:-}" ]]; then
+  fail "This script requires bash. Run it with: bash $0"
+fi
+
+# Detect laptop hardware (informational — drives logging, not behavior)
+if [[ -f /sys/class/dmi/id/chassis_type ]]; then
+  CHASSIS_TYPE=$(cat /sys/class/dmi/id/chassis_type 2>/dev/null || echo "0")
+  # DMI chassis types 8/9/10/14 = portable/laptop/notebook/sub-notebook
+  case "$CHASSIS_TYPE" in
+    8|9|10|14)
+      VENDOR=$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null | tr -d '\n' || echo "unknown")
+      MODEL=$(cat /sys/class/dmi/id/product_family 2>/dev/null | tr -d '\n' || echo "")
+      info "Detected: laptop hardware ($VENDOR ${MODEL:-<unknown model>})"
+      ;;
+    *)
+      warn "Detected non-laptop chassis (type $CHASSIS_TYPE) — TLP charge thresholds will be skipped if no battery is found."
+      ;;
+  esac
+fi
+
+info "Detected: $(grep PRETTY_NAME /etc/os-release | cut -d= -f2 | tr -d '"')"
+info "User: $(whoami) | Home: $HOME"
+info "GitHub user: ${GITHUB_USER:-<will auto-detect>} | Org: ${GITHUB_ORG:-<none>} | Repos dir: $REPOS_DIR"
+info "Shell: bash $BASH_VERSION"
+if [[ -n "${GH_TOKEN:-}" ]]; then
+  info "Mode: non-interactive (GH_TOKEN set)"
+elif [[ "$INTERACTIVE" == "true" ]]; then
+  info "Mode: interactive (terminal detected)"
+else
+  info "Mode: non-interactive (piped, no GH_TOKEN)"
+fi
+
+# Harvest sudo credentials up front so the password prompt doesn't ambush
+# us mid-install when the credential cache expires.
+sudo -v
+# Keep sudo alive in the background — prevents timeout during long installs.
+(while kill -0 "$$" 2>/dev/null; do sudo -n true; sleep 50; done) &
+
+# --- Create workstation config template if it doesn't exist ---
+WS_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/workstation-bootstrap"
+if [[ ! -f "$WS_CONFIG_DIR/config" ]]; then
+  mkdir -p "$WS_CONFIG_DIR"
+  if [[ -n "${GITHUB_ORG:-}" ]]; then
+    _ws_org_line="GITHUB_ORG=\"${GITHUB_ORG}\""
+  else
+    _ws_org_line='#GITHUB_ORG=""'
+  fi
+  if [[ -n "${GITHUB_DEFAULT_OWNER:-}" ]]; then
+    _ws_owner_line="GITHUB_DEFAULT_OWNER=\"${GITHUB_DEFAULT_OWNER}\""
+  else
+    _ws_owner_line='#GITHUB_DEFAULT_OWNER=""'
+  fi
+  cat > "$WS_CONFIG_DIR/config" << WS_CONF
+# ============================================================================
+# Workstation bootstrap config — sourced by setup-*-workstation.sh scripts
+# Location: ~/.config/workstation-bootstrap/config
+#
+# This file personalizes your workstation without modifying the bootstrap
+# scripts themselves. The scripts stay portable; your preferences live here.
+# Re-running any bootstrap script will NOT overwrite this file.
+# ============================================================================
+
+# --- GitHub org to clone alongside personal repos --------------------------
+# Set this to also clone all repos from a GitHub organization during
+# bootstrap. Leave empty to only clone your personal repos.
+# The bootstrap script clones BOTH personal and org repos when set.
+${_ws_org_line}
+
+# --- Default owner for new repos ------------------------------------------
+# Used by the 'ghnew' alias to default gh repo create to this owner.
+# Leave empty to default to your personal account.
+${_ws_owner_line}
+WS_CONF
+  info "Created workstation config at $WS_CONFIG_DIR/config"
+  info "Edit this file to set your GitHub org and other preferences."
+fi
+
+# --- 1. System update & base packages --------------------------------------
+section "1/$TOTAL_STEPS — System Update & Base Packages"
+
+sudo apt-get update -qq
+sudo apt-get upgrade -y -qq
+
+BASE_PKGS=(
+  build-essential
+  curl
+  wget
+  git
+  unzip
+  zip
+  gnupg
+  lsb-release
+  ca-certificates
+  software-properties-common
+  apt-transport-https
+  man-db
+  less
+  openssh-client
+  openssh-server           # [CHANGE] SSH server for remote access
+  dnsutils
+  net-tools
+  traceroute
+  nmap
+  whois
+  htop
+  ncdu
+  nano
+  nfs-common                 # NFS client for mounting network shares
+)
+
+info "Installing base packages..."
+sudo apt-get install -y -qq "${BASE_PKGS[@]}"
+
+# Enable SSH and guest agent
+sudo systemctl enable --now ssh
+
+success "Base packages installed."
+
+# --- 2. Git config ----------------------------------------------------------
+section "2/$TOTAL_STEPS — Git Configuration"
+
+git config --global init.defaultBranch main
+git config --global pull.rebase true
+git config --global push.autoSetupRemote true
+git config --global core.editor "nano"
+git config --global alias.st "status -sb"
+git config --global alias.lg "log --oneline --graph --decorate -20"
+git config --global alias.co "checkout"
+git config --global alias.br "branch"
+git config --global alias.unstage "reset HEAD --"
+git config --global alias.amend "commit --amend --no-edit"
+git config --global alias.wip "!git add -A && git commit -m 'WIP'"
+success "Git defaults configured (identity set after GitHub auth in step 10)."
+
+# --- 3. Python 3 + pip + venv -----------------------------------------------
+section "3/$TOTAL_STEPS — Python 3 + pip + venv"
+
+sudo apt-get install -y -qq python3 python3-pip python3-venv python3-full
+require python3 "Python 3"
+success "Python $(python3 --version 2>&1 | awk '{print $2}') ready."
+
+# --- 4. Node.js via nvm -----------------------------------------------------
+section "4/$TOTAL_STEPS — Node.js (LTS via nvm)"
+
+export NVM_DIR="$HOME/.nvm"
+mkdir -p "$NVM_DIR"
+
+if [[ ! -s "$NVM_DIR/nvm.sh" ]]; then
+  info "Installing nvm..."
+  # Ensure .bashrc exists so nvm's installer doesn't complain about missing profile
+  touch "$HOME/.bashrc"
+  curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | \
+    PROFILE=/dev/null bash
+fi
+
+if [[ -s "$NVM_DIR/nvm.sh" ]]; then
+  # shellcheck source=/dev/null
+  . "$NVM_DIR/nvm.sh"
+else
+  fail "nvm installed but nvm.sh not found at $NVM_DIR/nvm.sh. Check network/git."
+fi
+
+if ! command_exists node; then
+  info "Installing Node.js LTS..."
+  nvm install --lts
+  nvm alias default 'lts/*'
+else
+  info "Node already installed, ensuring LTS is default..."
+  nvm install --lts --default 2>/dev/null || true
+fi
+
+require node "Node.js"
+success "Node $(node -v) + npm $(npm -v) ready."
+
+# --- 5. Go ------------------------------------------------------------------
+section "5/$TOTAL_STEPS — Go (latest stable)"
+
+GO_VERSION="1.23.6"
+GO_INSTALLED="$(go version 2>/dev/null | grep -oP 'go\K[0-9]+\.[0-9]+\.[0-9]+' || echo 'none')"
+
+if [[ "$GO_INSTALLED" != "$GO_VERSION" ]]; then
+  info "Installing Go ${GO_VERSION}..."
+  curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tar.gz
+  sudo rm -rf /usr/local/go
+  sudo tar -C /usr/local -xzf /tmp/go.tar.gz
+  rm /tmp/go.tar.gz
+fi
+
+require go "Go"
+success "Go $(go version | awk '{print $3}') ready."
+
+# --- 6. AWS CLI v2 + Granted ------------------------------------------------
+section "6/$TOTAL_STEPS — AWS CLI v2 + Granted (account switching)"
+
+if ! command_exists aws || [[ "$(aws --version 2>&1)" != *"aws-cli/2"* ]]; then
+  info "Installing AWS CLI v2..."
+  cd /tmp
+  curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip
+  unzip -qo awscliv2.zip
+  sudo ./aws/install --update
+  rm -rf aws awscliv2.zip
+  cd ~
+fi
+require aws "AWS CLI"
+success "AWS CLI $(aws --version 2>&1 | awk '{print $1}') ready."
+
+# Granted: repo moved from common-fate/granted to fwdcloudsec/granted after
+# Common Fate wound down. The releases.commonfate.io CDN and APT repo are dead.
+# Download directly from GitHub releases. Granted is MIT-licensed and will keep
+# working, but expect no new releases.
+# Docs: https://docs.commonfate.io/granted/getting-started
+if ! command_exists granted; then
+  info "Installing Granted..."
+  GRANTED_VERSION=$(curl -fsSL https://api.github.com/repos/fwdcloudsec/granted/releases/latest | \
+    python3 -c 'import sys,json;print(json.load(sys.stdin)["tag_name"].lstrip("v"))' 2>/dev/null) || true
+
+  if [[ -n "${GRANTED_VERSION:-}" ]]; then
+    GRANTED_URL="https://github.com/fwdcloudsec/granted/releases/download/v${GRANTED_VERSION}/granted_${GRANTED_VERSION}_linux_x86_64.tar.gz"
+    curl -fsSL "$GRANTED_URL" -o /tmp/granted.tar.gz
+    tar -xzf /tmp/granted.tar.gz -C /tmp granted assume
+    sudo install -m 0755 /tmp/granted /usr/local/bin/granted
+    sudo install -m 0755 /tmp/assume /usr/local/bin/assume
+    rm -f /tmp/granted.tar.gz /tmp/granted /tmp/assume
+  else
+    warn "Could not determine Granted version. Skipping."
+  fi
+fi
+
+if command_exists granted; then
+  success "Granted installed — use 'assume <profile>' to switch AWS accounts."
+else
+  warn "Granted not available — install manually: https://docs.commonfate.io/granted/getting-started"
+fi
+
+# --- 7. Terraform + tfswitch ------------------------------------------------
+section "7/$TOTAL_STEPS — Terraform + tfswitch"
+
+if ! command_exists tfswitch; then
+  info "Installing tfswitch..."
+  curl -fsSL https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | sudo bash
+fi
+
+if command_exists tfswitch; then
+  success "tfswitch ready — run 'tfswitch' in any TF project to auto-select the right version."
+
+  if ! command_exists terraform; then
+    info "Installing latest Terraform via tfswitch..."
+    tfswitch --latest
+  fi
+else
+  warn "tfswitch install failed. Installing Terraform via HashiCorp APT repo instead..."
+  wget -qO- https://apt.releases.hashicorp.com/gpg | \
+    gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg >/dev/null
+  echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
+    https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
+    sudo tee /etc/apt/sources.list.d/hashicorp.list >/dev/null
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq terraform
+fi
+
+if command_exists terraform; then
+  success "Terraform $(terraform version -json 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin)["terraform_version"])' 2>/dev/null || terraform version | head -1) ready."
+else
+  warn "Terraform not installed — run 'tfswitch' after setup to install."
+fi
+
+# --- 8. kubectl + eksctl + Helm ---------------------------------------------
+section "8/$TOTAL_STEPS — kubectl + eksctl + Helm"
+
+if ! command_exists kubectl; then
+  info "Installing kubectl..."
+  KUBECTL_VERSION=$(curl -fsSL https://dl.k8s.io/release/stable.txt)
+  curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+    -o /tmp/kubectl
+  sudo install -o root -g root -m 0755 /tmp/kubectl /usr/local/bin/kubectl
+  rm /tmp/kubectl
+fi
+require kubectl "kubectl"
+success "kubectl $(kubectl version --client -o json 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin)["clientVersion"]["gitVersion"])' 2>/dev/null || echo 'installed') ready."
+
+if ! command_exists eksctl; then
+  info "Installing eksctl..."
+  PLATFORM="$(uname -s)_amd64"
+  curl -fsSL "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_${PLATFORM}.tar.gz" | \
+    tar xz -C /tmp
+  sudo install -m 0755 /tmp/eksctl /usr/local/bin/eksctl
+  rm -f /tmp/eksctl
+fi
+require eksctl "eksctl"
+success "eksctl $(eksctl version 2>/dev/null || echo 'installed') ready."
+
+if ! command_exists helm; then
+  info "Installing Helm..."
+  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+fi
+require helm "Helm"
+success "Helm $(helm version --short 2>/dev/null || echo 'installed') ready."
+
+# --- 9. Docker Engine -------------------------------------------------------
+# [CHANGE] Full Docker Engine with daemon, not CLI-only.
+# Uses the Ubuntu repo (not Debian) since we're on Xubuntu 24.04.
+section "9/$TOTAL_STEPS — Docker Engine + Compose"
+
+if ! command_exists docker; then
+  info "Installing Docker Engine..."
+  sudo mkdir -p /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+    sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg 2>/dev/null
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+    https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | \
+    sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq docker-ce docker-ce-cli containerd.io docker-compose-plugin
+fi
+
+# Add current user to docker group (no sudo needed for docker commands)
+if ! groups "$USER" | grep -q docker; then
+  sudo usermod -aG docker "$USER"
+  info "Added $USER to docker group (takes effect on next login)"
+fi
+
+# Ensure Docker daemon is running
+sudo systemctl enable --now docker
+
+require docker "Docker"
+success "Docker Engine + Compose plugin ready. Run 'docker run hello-world' to verify."
+
+# --- 10. GitHub CLI (gh) + Clone Repos --------------------------------------
+section "10/$TOTAL_STEPS — GitHub CLI + Clone Repos"
+
+if ! command_exists gh; then
+  info "Installing GitHub CLI..."
+  sudo mkdir -p -m 755 /etc/apt/keyrings
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
+    sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+  sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] \
+    https://cli.github.com/packages stable main" | \
+    sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq gh
+fi
+require gh "GitHub CLI"
+success "gh $(gh --version 2>/dev/null | head -1) ready."
+
+if ! gh auth status &>/dev/null; then
+  if [[ -n "${GH_TOKEN:-}" ]]; then
+    info "Authenticating GitHub CLI via GH_TOKEN..."
+    _SAVED_TOKEN="$GH_TOKEN"
+    unset GH_TOKEN
+    if echo "$_SAVED_TOKEN" | gh auth login --with-token 2>&1; then
+      # Re-export so gh commands work for the rest of this step.
+      # We'll clear it after repo cloning is done.
+      export GH_TOKEN="$_SAVED_TOKEN"
+    else
+      warn "GH_TOKEN authentication failed (bad token? expired? wrong scopes?)."
+      info "Continuing without GitHub auth — remaining tools will still install."
+      info "After setup, fix with: gh auth login"
+      info "Or re-run with a valid token: GH_TOKEN=ghp_xxx bash $(basename "$0")"
+    fi
+    unset _SAVED_TOKEN
+  else
+    warn "GitHub CLI is not authenticated."
+    info "Run 'gh auth login' after setup to enable repo cloning."
+    info "Or re-run with: GH_TOKEN=ghp_xxx bash $(basename "$0")"
+  fi
+fi
+
+if gh auth status &>/dev/null; then
+  success "GitHub CLI authenticated."
+  gh auth setup-git
+
+  if [[ -z "$GITHUB_USER" ]]; then
+    GITHUB_USER=$(gh api user -q '.login' 2>/dev/null || true)
+    [[ -n "$GITHUB_USER" ]] && info "Auto-detected GitHub user: $GITHUB_USER"
+  fi
+
+  if [[ -z "$(git config --global user.name 2>/dev/null || true)" ]]; then
+    GH_NAME=$(gh api user -q '.name // empty' 2>/dev/null || true)
+    if [[ -n "${GH_NAME:-}" ]]; then
+      git config --global user.name "$GH_NAME"
+      GIT_NAME="$GH_NAME"
+      info "Auto-set git user.name from GitHub profile: $GH_NAME"
+    fi
+  fi
+
+  if [[ -z "$(git config --global user.email 2>/dev/null || true)" ]]; then
+    GH_EMAIL=$(gh api user/emails -q '.[] | select(.primary) | .email' 2>/dev/null || true)
+    [[ -z "${GH_EMAIL:-}" ]] && GH_EMAIL=$(gh api user -q '.email // empty' 2>/dev/null || true)
+    if [[ -n "${GH_EMAIL:-}" ]]; then
+      git config --global user.email "$GH_EMAIL"
+      GIT_EMAIL="$GH_EMAIL"
+      info "Auto-set git user.email from GitHub profile: $GH_EMAIL"
+    else
+      warn "Could not detect email from GitHub. Set manually: git config --global user.email you@example.com"
+    fi
+  fi
+else
+  warn "GitHub auth skipped — repo cloning will only work for public repos."
+fi
+
+# --- Clone repos (while auth is fresh) ---
+info "Cloning repos while GitHub auth is active..."
+
+mkdir -p "$REPOS_DIR"
+
+if ! grep -q "github.com" "$HOME/.ssh/known_hosts" 2>/dev/null; then
+  mkdir -p "$HOME/.ssh"
+  ssh-keyscan -t ed25519 github.com >> "$HOME/.ssh/known_hosts" 2>/dev/null || true
+fi
+
+if gh auth status &>/dev/null; then
+  info "Fetching repo list for $GITHUB_USER..."
+
+  REPO_LIST=$(gh repo list "$GITHUB_USER" --limit 200 --json name,isPrivate \
+    --jq '.[] | "\(.name)\t\(.isPrivate)"' 2>/dev/null) || true
+
+  if [[ -z "${REPO_LIST:-}" ]]; then
+    warn "No repos found for $GITHUB_USER (or API rate limited)."
+  else
+    CLONE_COUNT=0
+    SKIP_COUNT=0
+    FAIL_COUNT=0
+
+    while IFS=$'\t' read -r REPO_NAME IS_PRIVATE; do
+      DEST="$REPOS_DIR/$REPO_NAME"
+
+      if [[ -d "$DEST" ]]; then
+        skip "$REPO_NAME (already cloned)"
+        ((SKIP_COUNT++)) || true
+      else
+        PRIVATE_TAG=""
+        [[ "$IS_PRIVATE" == "true" ]] && PRIVATE_TAG=" 🔒"
+
+        HTTPS_URL="https://github.com/${GITHUB_USER}/${REPO_NAME}.git"
+        if git clone --quiet "$HTTPS_URL" "$DEST" 2>/dev/null; then
+          success "$REPO_NAME${PRIVATE_TAG}"
+          ((CLONE_COUNT++)) || true
+        else
+          warn "Failed to clone $REPO_NAME"
+          ((FAIL_COUNT++)) || true
+        fi
+      fi
+    done <<< "$REPO_LIST"
+
+    echo ""
+    info "Repos ($GITHUB_USER): $CLONE_COUNT cloned, $SKIP_COUNT already present, $FAIL_COUNT failed"
+
+    # --- Clone org repos (if GITHUB_ORG is set) ---
+    if [[ -n "${GITHUB_ORG:-}" ]] && [[ "$GITHUB_ORG" != "$GITHUB_USER" ]]; then
+      echo ""
+      info "Fetching repo list for org: $GITHUB_ORG..."
+
+      ORG_REPO_LIST=$(gh repo list "$GITHUB_ORG" --limit 200 --json name,isPrivate \
+        --jq '.[] | "\(.name)\t\(.isPrivate)"' 2>/dev/null) || true
+
+      if [[ -z "${ORG_REPO_LIST:-}" ]]; then
+        warn "No repos found for $GITHUB_ORG (or no access / API rate limited)."
+      else
+        ORG_CLONE_COUNT=0
+        ORG_SKIP_COUNT=0
+        ORG_FAIL_COUNT=0
+
+        while IFS=$'\t' read -r REPO_NAME IS_PRIVATE; do
+          DEST="$REPOS_DIR/$REPO_NAME"
+
+          if [[ -d "$DEST" ]]; then
+            skip "$REPO_NAME (already cloned)"
+            ((ORG_SKIP_COUNT++)) || true
+          else
+            PRIVATE_TAG=""
+            [[ "$IS_PRIVATE" == "true" ]] && PRIVATE_TAG=" 🔒"
+
+            HTTPS_URL="https://github.com/${GITHUB_ORG}/${REPO_NAME}.git"
+            if git clone --quiet "$HTTPS_URL" "$DEST" 2>/dev/null; then
+              success "$REPO_NAME${PRIVATE_TAG} (${GITHUB_ORG})"
+              ((ORG_CLONE_COUNT++)) || true
+            else
+              warn "Failed to clone $GITHUB_ORG/$REPO_NAME"
+              ((ORG_FAIL_COUNT++)) || true
+            fi
+          fi
+        done <<< "$ORG_REPO_LIST"
+
+        echo ""
+        info "Org repos ($GITHUB_ORG): $ORG_CLONE_COUNT cloned, $ORG_SKIP_COUNT already present, $ORG_FAIL_COUNT failed"
+      fi
+    fi
+  fi
+  _REPOS_CLONED=1
+else
+  warn "GitHub CLI not authenticated — skipping repo cloning."
+  info "Authenticate later with 'gh auth login', then run:"
+  info "  cd ~/repos && gh repo list $GITHUB_USER --limit 200 --json name -q '.[].name' | xargs -I{} gh repo clone $GITHUB_USER/{}"
+fi
+
+# Cloning is done — clear GH_TOKEN so it doesn't interfere with npm,
+# VS Code, or other tools that respect GitHub tokens in the environment.
+unset GH_TOKEN 2>/dev/null || true
+
+# --- 11. VS Code -------------------------------------------------------------
+section "11/$TOTAL_STEPS — VS Code"
+
+if ! command_exists code; then
+  info "Installing VS Code via Microsoft APT repo..."
+  wget -qO- https://packages.microsoft.com/keys/microsoft.asc | \
+    gpg --dearmor | sudo tee /usr/share/keyrings/packages.microsoft.gpg >/dev/null
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/packages.microsoft.gpg] \
+    https://packages.microsoft.com/repos/code stable main" | \
+    sudo tee /etc/apt/sources.list.d/vscode.list >/dev/null
+  sudo apt-get update -qq
+  # Pre-seed debconf to avoid interactive prompt about adding Microsoft repo.
+  # The package's postinst script asks this via debconf even with -y.
+  # See: https://code.visualstudio.com/docs/setup/linux
+  echo "code code/add-microsoft-repo boolean true" | sudo debconf-set-selections
+  sudo apt-get install -y -qq code
+fi
+require code "VS Code"
+success "VS Code $(code --version 2>/dev/null | head -1 || echo 'installed') ready."
+
+VSCODE_EXTENSIONS=(
+  # --- Infrastructure & DevOps ---
+  hashicorp.terraform
+  hashicorp.hcl
+  ms-azuretools.vscode-docker
+  amazonwebservices.aws-toolkit-vscode
+
+  # --- Languages ---
+  ms-python.python
+  golang.go
+
+  # --- AI ---
+  anthropic.claude-code
+
+  # --- Quality & Collaboration ---
+  redhat.vscode-yaml
+  eamodio.gitlens
+  timonwong.shellcheck
+
+  # --- Remote ---
+  ms-vscode-remote.remote-ssh
+)
+
+info "Installing VS Code extensions..."
+INSTALLED_EXT=$(code --list-extensions 2>/dev/null || true)
+for ext in "${VSCODE_EXTENSIONS[@]}"; do
+  ext_id="${ext%%#*}"
+  ext_id="${ext_id// /}"
+  if echo "$INSTALLED_EXT" | grep -qi "$ext_id"; then
+    skip "$ext_id (already installed)"
+  else
+    code --install-extension "$ext_id" --force 2>/dev/null && \
+      success "$ext_id" || warn "Failed to install $ext_id"
+  fi
+done
+
+VSCODE_SETTINGS_DIR="$HOME/.config/Code/User"
+VSCODE_SETTINGS="$VSCODE_SETTINGS_DIR/settings.json"
+
+if [[ ! -f "$VSCODE_SETTINGS" ]]; then
+  info "Writing VS Code settings..."
+  mkdir -p "$VSCODE_SETTINGS_DIR"
+  cat > "$VSCODE_SETTINGS" << 'VSCODE_JSON'
+{
+  // --- Editor behavior ---
+  "editor.fontSize": 15,
+  "editor.fontFamily": "'Droid Sans Mono', 'monospace', monospace",
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true,
+  "editor.formatOnSave": true,
+  "editor.trimAutoWhitespace": true,
+  "editor.renderWhitespace": "trailing",
+  "editor.suggestSelection": "first",
+  "editor.linkedEditing": true,
+  "editor.bracketPairColorization.enabled": true,
+  "editor.guides.bracketPairs": "active",
+
+  // --- Files ---
+  "files.autoSave": "onFocusChange",
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+
+  // --- Theme ---
+  "workbench.colorTheme": "Default Dark Modern",
+
+  // --- Terminal ---
+  "terminal.integrated.defaultProfile.linux": "bash",
+  "terminal.integrated.fontSize": 14,
+
+  // --- Git ---
+  "git.autofetch": true,
+  "git.confirmSync": false,
+  "git.enableSmartCommit": true,
+
+  // --- Terraform ---
+  "terraform.experimentalFeatures.validateOnSave": true,
+  "[terraform]": {
+    "editor.defaultFormatter": "hashicorp.terraform",
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2
+  },
+  "[terraform-vars]": {
+    "editor.defaultFormatter": "hashicorp.terraform",
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2
+  },
+
+  // --- YAML ---
+  "[yaml]": {
+    "editor.tabSize": 2,
+    "editor.autoIndent": "keep"
+  },
+
+  // --- JSON ---
+  "[json]": {
+    "editor.tabSize": 2,
+    "editor.defaultFormatter": "vscode.json-language-features"
+  },
+  "[jsonc]": {
+    "editor.tabSize": 2,
+    "editor.defaultFormatter": "vscode.json-language-features"
+  },
+
+  // --- Markdown ---
+  "[markdown]": {
+    "editor.wordWrap": "on"
+  },
+
+  // --- Docker ---
+  "[dockerfile]": {
+    "editor.tabSize": 4
+  },
+
+  // --- Misc ---
+  "telemetry.telemetryLevel": "off",
+  "update.mode": "default",
+  "extensions.autoUpdate": true
+}
+VSCODE_JSON
+  success "VS Code settings written."
+else
+  skip "VS Code settings already exist (not overwriting)."
+fi
+
+# --- 12. Claude Code --------------------------------------------------------
+section "12/$TOTAL_STEPS — Claude Code"
+
+if ! command_exists claude; then
+  info "Installing Claude Code..."
+  npm install -g --no-update-notifier @anthropic-ai/claude-code
+fi
+
+if command_exists claude; then
+  success "Claude Code installed. Run 'claude' to authenticate and get started."
+else
+  warn "Claude Code install failed. Try manually: npm install -g @anthropic-ai/claude-code"
+fi
+
+# --- 13. Quality-of-life CLI tools ------------------------------------------
+section "13/$TOTAL_STEPS — Quality-of-Life CLI Tools"
+
+QOL_PKGS=(jq tree tmux shellcheck direnv pipx)
+sudo apt-get install -y -qq "${QOL_PKGS[@]}"
+
+if ! command_exists bat && ! command_exists batcat; then
+  sudo apt-get install -y -qq bat 2>/dev/null || true
+fi
+
+if ! command_exists rg; then
+  sudo apt-get install -y -qq ripgrep 2>/dev/null || true
+fi
+
+if ! command_exists fd && ! command_exists fdfind; then
+  sudo apt-get install -y -qq fd-find 2>/dev/null || true
+fi
+
+if ! command_exists tldr; then
+  info "Installing tldr..."
+  pip install --break-system-packages --quiet tldr 2>/dev/null || \
+    pipx install tldr 2>/dev/null || true
+fi
+
+if ! command_exists fzf; then
+  info "Installing fzf..."
+  [[ -d "$HOME/.fzf" ]] && rm -rf "$HOME/.fzf"
+  git clone --depth 1 https://github.com/junegunn/fzf.git "$HOME/.fzf"
+  "$HOME/.fzf/install" --key-bindings --completion --no-update-rc --no-bash --no-zsh --no-fish < /dev/null
+fi
+
+if ! command_exists yq; then
+  info "Installing yq..."
+  YQ_VERSION=$(curl -fsSL https://api.github.com/repos/mikefarah/yq/releases/latest | \
+    python3 -c 'import sys,json;print(json.load(sys.stdin)["tag_name"])') || true
+  if [[ -n "${YQ_VERSION:-}" ]]; then
+    sudo wget -q "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+      -O /usr/local/bin/yq
+    sudo chmod +x /usr/local/bin/yq
+  else
+    warn "Could not fetch yq version. Skipping."
+  fi
+fi
+
+# [CHANGE] Starship: install to /usr/local/bin. Unlike Crostini, sudo works
+# normally on a full Xubuntu install, so no need for the ~/.local/bin workaround.
+if ! command_exists starship; then
+  info "Installing Starship prompt..."
+  curl -fsSL https://starship.rs/install.sh | sh -s -- -y 2>&1 | \
+    grep -E "^(>|✓|Starship)" || true
+fi
+
+INSTALLED_QOL=""
+for tool in jq yq tree tmux shellcheck direnv fzf rg pipx tldr starship; do
+  command_exists "$tool" && INSTALLED_QOL="$INSTALLED_QOL $tool"
+done
+command_exists batcat && INSTALLED_QOL="$INSTALLED_QOL bat(cat)"
+command_exists bat && INSTALLED_QOL="$INSTALLED_QOL bat"
+command_exists fdfind && INSTALLED_QOL="$INSTALLED_QOL fd(find)"
+command_exists fd && INSTALLED_QOL="$INSTALLED_QOL fd"
+
+success "CLI tools:${INSTALLED_QOL}"
+
+# --- 14. Shell configuration ------------------------------------------------
+section "14/$TOTAL_STEPS — Shell Configuration"
+
+BASHRC="$HOME/.bashrc"
+MARKER="# >>> setup-ubuntu-laptop >>>"
+
+# Remove old block if re-running. Migration-safe: handles markers from any
+# of the sibling scripts in case this laptop was previously imaged differently
+# or the user is switching between bootstrap variants.
+for marker_check in \
+    "# >>> setup-crostini-lab >>>" \
+    "# >>> setup-xubuntu-workstation >>>" \
+    "# >>> setup-fedora-workstation >>>" \
+    "$MARKER"; do
+  if grep -q "$marker_check" "$BASHRC" 2>/dev/null; then
+    info "Removing previous config block from .bashrc..."
+    end_check="${marker_check/>>>/<<<}"
+    sed -i "/${marker_check//\//\\/}/,/${end_check//\//\\/}/d" "$BASHRC"
+  fi
+done
+
+info "Appending config to .bashrc..."
+cat >> "$BASHRC" << 'BASHRC_BLOCK'
+# >>> setup-ubuntu-laptop >>>
+
+# --- PATH ---
+export PATH="$HOME/.local/bin:$HOME/bin:$HOME/go/bin:/usr/local/go/bin:$PATH"
+
+# --- Workstation config ---
+WS_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/workstation-bootstrap/config"
+[[ -f "$WS_CONFIG" ]] && . "$WS_CONFIG"
+
+# --- nvm ---
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/bash_completion" ] && . "$NVM_DIR/bash_completion"
+
+# --- fzf ---
+[ -f "$HOME/.fzf.bash" ] && . "$HOME/.fzf.bash"
+
+# --- direnv ---
+command -v direnv &>/dev/null && eval "$(direnv hook bash)"
+
+# --- Starship prompt ---
+command -v starship &>/dev/null && eval "$(starship init bash)"
+
+# --- Granted (AWS account switching) ---
+alias assume="source assume"
+
+# --- Aliases: navigation ---
+alias ll='ls -alFh --color=auto'
+alias la='ls -A --color=auto'
+alias l='ls -CF --color=auto'
+alias ..='cd ..'
+alias ...='cd ../..'
+alias repos='cd ~/repos'
+
+# --- Aliases: bat ---
+command -v batcat &>/dev/null && alias bat='batcat'
+
+# --- Aliases: fd ---
+command -v fdfind &>/dev/null && alias fd='fdfind'
+
+# --- Aliases: docker ---
+alias dc='docker compose'
+alias dps='docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"'
+alias dlog='docker logs -f'
+
+# --- Aliases: kubernetes ---
+alias k='kubectl'
+alias kgp='kubectl get pods'
+alias kgs='kubectl get svc'
+alias kgn='kubectl get nodes'
+alias kns='kubectl config set-context --current --namespace'
+alias kctx='kubectl config use-context'
+
+# --- Aliases: terraform ---
+alias tf='terraform'
+alias tfi='terraform init'
+alias tfp='terraform plan'
+alias tfa='terraform apply'
+alias tfs='tfswitch'
+
+# --- Aliases: git ---
+alias g='git'
+alias gs='git status -sb'
+alias gd='git diff'
+alias gp='git push'
+alias gl='git lg'
+alias gco='git checkout'
+alias gcb='git checkout -b'
+alias gwip='git wip'
+
+# --- Aliases: GitHub org ---
+if [[ -n "${GITHUB_DEFAULT_OWNER:-}" ]]; then
+  alias ghnew='gh repo create --owner "$GITHUB_DEFAULT_OWNER"'
+  alias ghclone='gh repo clone "$GITHUB_DEFAULT_OWNER"/'
+fi
+
+# --- Aliases: safety nets ---
+alias rm='rm -i'
+alias cp='cp -i'
+alias mv='mv -i'
+
+# --- AWS defaults (uncomment as needed) ---
+# export AWS_PROFILE=default
+# export AWS_DEFAULT_REGION=us-east-1
+
+# --- Functions ---
+
+# mkdir + cd in one shot
+mkcd() { mkdir -p "$1" && cd "$1"; }
+
+# Quick Python venv setup
+venv() {
+  local name="${1:-.venv}"
+  if [[ ! -d "$name" ]]; then
+    python3 -m venv "$name"
+    echo "Created venv: $name"
+  fi
+  # shellcheck disable=SC1091
+  source "$name/bin/activate"
+  echo "Activated: $name"
+}
+
+# Quick look at what's in your repos dir
+projects() {
+  echo ""
+  echo "📂 ~/repos:"
+  for dir in ~/repos/*/; do
+    [[ -d "$dir/.git" ]] || continue
+    local name branch dirty
+    name=$(basename "$dir")
+    branch=$(git -C "$dir" branch --show-current 2>/dev/null || echo "—")
+    dirty=""
+    [[ -n "$(git -C "$dir" status --porcelain 2>/dev/null)" ]] && dirty=" *"
+    printf "  %-30s (%s)%s\n" "$name" "$branch" "$dirty"
+  done
+  echo ""
+}
+
+# Pull all repos at once
+pull-all() {
+  local ok=0 fail=0
+  for dir in ~/repos/*/; do
+    if [[ -d "$dir/.git" ]]; then
+      local name
+      name=$(basename "$dir")
+      if git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+        echo -e "\033[0;32m  ✓\033[0m $name"
+        ((ok++)) || true
+      else
+        echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+        ((fail++)) || true
+      fi
+    fi
+  done
+  echo ""
+  echo "Pulled: $ok ok, $fail need attention"
+}
+
+# <<< setup-ubuntu-laptop <<<
+BASHRC_BLOCK
+
+success ".bashrc configured."
+
+# Starship config
+mkdir -p "$HOME/.config"
+cat > "$HOME/.config/starship.toml" << 'STARSHIP_CONF'
+# ============================================================================
+# Starship prompt — setup-ubuntu-laptop
+# Full absolute path always visible. Context modules (aws, k8s, terraform,
+# etc.) only appear when active. Context on line 1, path + cursor on line 2.
+# ============================================================================
+
+scan_timeout = 100
+
+format = """
+$git_branch\
+$git_status\
+$python\
+$nodejs\
+$golang\
+$terraform\
+$aws\
+$kubernetes\
+$docker_context\
+$cmd_duration\
+$line_break\
+${custom.os}$hostname$directory\
+$character"""
+
+[character]
+success_symbol = "[❯](bold green)"
+error_symbol = "[❯](bold red)"
+
+[directory]
+truncation_length = 0
+truncate_to_repo = false
+format = "[$path]($style) "
+style = "bold cyan"
+
+[git_branch]
+symbol = " "
+format = "[$symbol$branch(:$remote_branch)]($style) "
+style = "bold purple"
+
+[git_status]
+format = '([\[$all_status$ahead_behind\]]($style) )'
+style = "bold red"
+
+[python]
+format = '[${symbol}${pyenv_prefix}(${version} )(\($virtualenv\) )]($style)'
+symbol = "🐍 "
+style = "yellow"
+
+[nodejs]
+format = "[$symbol($version )]($style)"
+symbol = "⬡ "
+style = "bold green"
+
+[golang]
+format = "[$symbol($version )]($style)"
+symbol = "🐹 "
+style = "bold cyan"
+
+[terraform]
+format = "[$symbol$workspace]($style) "
+symbol = "💠 "
+style = "bold 105"
+
+[aws]
+format = '[$symbol($profile )(\($region\) )]($style)'
+symbol = "☁️  "
+style = "bold 208"
+
+[kubernetes]
+disabled = false
+format = '[$symbol$context( \($namespace\))]($style) '
+symbol = "⎈ "
+style = "bold blue"
+
+# [CHANGE] Docker context — shows when DOCKER_CONTEXT or active compose project
+[docker_context]
+format = "[$symbol$context]($style) "
+symbol = "🐳 "
+style = "blue"
+only_with_files = true
+
+# --- OS: distro + version from /etc/os-release ------------------------------
+[custom.os]
+command = '. /etc/os-release 2>/dev/null && echo "${ID} ${VERSION_ID}"'
+when = "true"
+format = "[$output]($style) "
+style = "bold dimmed green"
+
+[cmd_duration]
+min_time = 3_000
+format = "took [$duration](bold yellow) "
+show_milliseconds = false
+
+[package]
+disabled = true
+
+[username]
+disabled = true
+
+[hostname]
+disabled = false
+ssh_only = false            # Always show hostname — this is a remote workstation
+format = "[$hostname](bold dimmed green):"
+STARSHIP_CONF
+success "Starship config written."
+
+# --- 15. Laptop power management & firmware updates ------------------------
+# TLP for battery management and ThinkPad-specific tuning. Replaces Ubuntu
+# Desktop's default power-profiles-daemon, which conflicts with TLP at the
+# /sys/devices level (both want to write CPU governor, ASPM, platform
+# profile, etc.). fwupd for LVFS firmware updates — most ThinkPads receive
+# microcode, EC firmware, Thunderbolt firmware, and UEFI updates this way,
+# and a refurbished unit is likely on stale firmware.
+section "15/$TOTAL_STEPS — Laptop Power Management & Firmware"
+
+# Remove power-profiles-daemon if present (conflicts with TLP). Ubuntu Desktop
+# ships PPD enabled by default starting 22.04 — GNOME's power-mode toggle
+# uses it, but TLP is strictly more capable for ThinkPad hardware (charge
+# thresholds, granular ASPM, USB autosuspend allowlists).
+if systemctl is-active --quiet power-profiles-daemon 2>/dev/null; then
+  info "Removing power-profiles-daemon (conflicts with TLP)..."
+  sudo systemctl disable --now power-profiles-daemon
+  sudo apt-get remove -y -qq power-profiles-daemon
+fi
+
+if ! dpkg -s tlp &>/dev/null; then
+  info "Installing TLP + Radio Device Wizard..."
+  # tlp-rdw = auto-disable wifi when ethernet plugged in, etc.
+  sudo apt-get install -y -qq tlp tlp-rdw
+fi
+
+sudo systemctl enable --now tlp.service
+
+# ThinkPad battery charge thresholds — start at 75%, stop at 80%.
+# Keeps the cell in its happy zone (much longer lifespan than 0-100% cycles).
+# Only applied if the kernel exposes the threshold sysfs knobs, which is true
+# for ThinkPads on recent kernels and a growing list of other vendors.
+# Override or remove /etc/tlp.d/01-thinkpad-charge-thresholds.conf if you
+# need full 100% charging for a long unplugged trip.
+if [[ -f /sys/class/power_supply/BAT0/charge_control_start_threshold ]]; then
+  TLP_OVERRIDE="/etc/tlp.d/01-thinkpad-charge-thresholds.conf"
+  if [[ ! -f "$TLP_OVERRIDE" ]]; then
+    sudo tee "$TLP_OVERRIDE" >/dev/null << 'TLP_CONF'
+# ThinkPad battery charge thresholds — extends battery lifespan.
+# Battery starts charging when below 75%, stops at 80%.
+# Comment these out (and `sudo tlp start`) if you need full 100% charge.
+START_CHARGE_THRESH_BAT0=75
+STOP_CHARGE_THRESH_BAT0=80
+TLP_CONF
+    info "Wrote ThinkPad charge thresholds to $TLP_OVERRIDE (75-80%)"
+    sudo systemctl restart tlp.service
+  else
+    skip "Charge thresholds already configured at $TLP_OVERRIDE"
+  fi
+else
+  info "Kernel does not expose charge thresholds for this hardware — skipping."
+fi
+
+success "TLP active — run 'sudo tlp-stat -s' to verify, 'sudo tlp-stat -b' for battery."
+
+# fwupd — firmware updates from LVFS
+# Run 'fwupdmgr refresh && fwupdmgr update' after setup to apply pending
+# firmware. Reboots may be required for some updates (UEFI, EC).
+if ! command_exists fwupdmgr; then
+  info "Installing fwupd..."
+  sudo apt-get install -y -qq fwupd
+fi
+sudo systemctl enable --now fwupd-refresh.timer 2>/dev/null || true
+success "fwupd ready — run 'fwupdmgr refresh && fwupdmgr update' to apply firmware."
+
+# --- 16. Tailscale (mesh VPN) ------------------------------------------------
+section "$TOTAL_STEPS/$TOTAL_STEPS — Tailscale (mesh VPN)"
+
+if ! command_exists tailscale; then
+  info "Installing Tailscale..."
+  curl -fsSL https://tailscale.com/install.sh | sh
+fi
+
+if command_exists tailscale; then
+  sudo systemctl enable --now tailscaled
+  success "Tailscale installed and service enabled."
+  if ! tailscale status &>/dev/null; then
+    info "Run 'sudo tailscale up' to authenticate and join your tailnet."
+    info "Then SSH from your Chromebook using the Tailscale IP or MagicDNS name."
+  else
+    success "Tailscale is connected: $(tailscale ip -4 2>/dev/null || echo '<run tailscale up>')"
+  fi
+else
+  warn "Tailscale install failed. Install manually: https://tailscale.com/download/linux"
+fi
+
+# ============================================================================
+section "🎉 Setup Complete!"
+echo ""
+echo -e "${GREEN}Everything is installed. Open a new terminal or run:${NC}"
+echo ""
+echo -e "  ${BOLD}source ~/.bashrc${NC}"
+echo ""
+echo -e "${YELLOW}Post-install checklist:${NC}"
+echo "  • Log out and back in (or reboot) so docker group takes effect"
+echo "  • Run 'docker run hello-world' to verify Docker"
+echo "  • Run 'aws configure' (or 'aws configure sso') to set up AWS creds"
+echo "  • Run 'assume <profile>' to switch AWS accounts via Granted"
+echo "  • Run 'claude' to authenticate Claude Code"
+echo "  • Run 'sudo tailscale up' to join your tailnet"
+echo "  • Run 'fwupdmgr refresh && fwupdmgr update' to apply firmware updates"
+echo "  • Run 'sudo tlp-stat -s' and 'sudo tlp-stat -b' to verify TLP"
+echo "  • Edit /etc/tlp.d/01-thinkpad-charge-thresholds.conf to change defaults"
+echo "  • Run 'projects' to see your cloned repos at a glance"
+echo "  • Run 'pull-all' to git pull every repo in ~/repos/"
+echo ""
+echo -e "${BLUE}Installed tools summary:${NC}"
+echo "  Languages:    Python 3, Node.js (nvm), Go, Bash"
+echo "  Cloud/Ops:    AWS CLI v2, Granted, Terraform, tfswitch, kubectl, eksctl, Helm"
+echo "  Containers:   Docker Engine + Compose"
+echo "  Dev tools:    git, gh, VS Code, Claude Code, jq, yq, ripgrep, fzf, bat, tmux"
+echo "  Shell:        Starship prompt, direnv, shellcheck"
+echo "  Remote:       SSH (port 22), Tailscale (mesh VPN)"
+echo "  Power:        TLP (battery 75-80% on ThinkPads), fwupd (LVFS firmware)"
+echo "  Config:       ~/.config/workstation-bootstrap/config (org: ${GITHUB_ORG:-<none>})"
+if [[ -n "${GITHUB_ORG:-}" ]]; then
+  echo "  Your code:    ~/repos/ (${GITHUB_USER:-<configure gh>} + ${GITHUB_ORG} repos)"
+else
+  echo "  Your code:    ~/repos/ (all ${GITHUB_USER:-<configure gh>} repos)"
+fi
+echo ""
+SIGNOFF_NAME="${GIT_NAME:-${GITHUB_USER:-hacker}}"
+SIGNOFF_FIRST=$(echo "$SIGNOFF_NAME" | awk '{print $1}')
+echo -e "${BOLD}Happy hacking, ${SIGNOFF_FIRST}. 🚀${NC}"


### PR DESCRIPTION
Forks `setup-xubuntu-workstation.sh` for a bare-metal Lenovo ThinkPad T14
running Ubuntu Desktop LTS. Drops XRDP and QEMU agent, adds TLP and fwupd.
See updated README/CLAUDE.md tables for the full diff matrix.

## Summary
- New `setup-ubuntu-laptop.sh` — fourth variant alongside Crostini, Xubuntu, and Fedora KDE
- Step 15 swapped from XRDP → TLP (with ThinkPad 75-80% charge thresholds) + fwupd LVFS firmware updates
- Removes `power-profiles-daemon` (conflicts with TLP), `qemu-guest-agent`, and Proxmox VM detection
- Marker migration loop in step 14 now handles all four sibling scripts so users can switch variants on the same machine
- README quick-start, comparison table (now 4 columns), "When to use which", and Requirements updated; CLAUDE.md script table + platform-differences bullets updated; "all three" → "all four"

## Validation
- `shellcheck --severity=warning --shell=bash setup-ubuntu-laptop.sh` passes clean
- No XRDP/qemu/xfwm4 references outside the lineage comment block
- Step count 16, all sequential (`TOTAL_STEPS=16`)
- 8 occurrences of `setup-ubuntu-laptop` in the script (header, BASHRC start/end markers, starship comment, MARKER variable, migration loop entry)
- `.github/workflows/shellcheck.yml` lists the new script

## Test plan
- [ ] ShellCheck status check passes
- [ ] Claude Code Review status check passes
- [ ] (Manual, post-merge) Run the script on a fresh Ubuntu Desktop ThinkPad and confirm TLP charge thresholds + fwupd timer activate

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ao4RhGApU8HRRip5QsYg8K)_