### PR TITLE
Remove Tailscale from workstation bootstrap scripts

### DIFF
--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -54,7 +54,6 @@
 #  13.  Quality-of-life CLI tools
 #  14.  Shell config (starship prompt, aliases, PATH wiring)
 #  15.  XRDP configuration (remote desktop — KDE Plasma X11 session)
-#  16.  Tailscale (mesh VPN)
 #
 # Changes from Xubuntu version:
 #   - Package manager: dnf instead of apt-get
@@ -145,7 +144,7 @@ require() {
   fi
 }
 
-TOTAL_STEPS=16
+TOTAL_STEPS=15
 
 # --- Preflight --------------------------------------------------------------
 section "Preflight Checks"
@@ -1309,41 +1308,6 @@ success "XRDP configured — connect via Microsoft Remote Desktop at $(hostname 
 info "Session type: KDE Plasma X11 (Wayland is not supported over XRDP)"
 info "Recommended: set RDP client resolution to 1920x1080 (4K causes rendering issues with software GL)"
 
-# --- 16. Tailscale (mesh VPN) ------------------------------------------------
-section "$TOTAL_STEPS/$TOTAL_STEPS — Tailscale (mesh VPN)"
-
-if ! command_exists tailscale; then
-  info "Installing Tailscale..."
-  # Tailscale's universal installer handles Fedora correctly.
-  # Using it instead of manually adding the DNF repo keeps the install
-  # path consistent across all three scripts.
-  curl -fsSL https://tailscale.com/install.sh | sh
-fi
-
-if command_exists tailscale; then
-  sudo systemctl enable --now tailscaled
-  success "Tailscale installed and service enabled."
-
-  # Open firewall for Tailscale if firewalld is running
-  if command_exists firewall-cmd && sudo firewall-cmd --state &>/dev/null; then
-    # Tailscale creates its own interface (tailscale0). Adding it to the
-    # trusted zone means traffic over the tailnet is unrestricted — which
-    # is the right default since Tailscale handles its own auth and ACLs.
-    sudo firewall-cmd --permanent --zone=trusted --add-interface=tailscale0 2>/dev/null || true
-    sudo firewall-cmd --reload
-    info "Added tailscale0 to firewalld trusted zone."
-  fi
-
-  if ! tailscale status &>/dev/null; then
-    info "Run 'sudo tailscale up' to authenticate and join your tailnet."
-    info "Then connect via RDP from your Chromebook using the Tailscale IP."
-  else
-    success "Tailscale is connected: $(tailscale ip -4 2>/dev/null || echo '<run tailscale up>')"
-  fi
-else
-  warn "Tailscale install failed. Install manually: https://tailscale.com/download/linux"
-fi
-
 # ============================================================================
 section "🎉 Setup Complete!"
 echo ""
@@ -1357,7 +1321,6 @@ echo "  • Run 'docker run hello-world' to verify Docker"
 echo "  • Run 'aws configure' (or 'aws configure sso') to set up AWS creds"
 echo "  • Run 'assume <profile>' to switch AWS accounts via Granted"
 echo "  • Run 'claude' to authenticate Claude Code"
-echo "  • Run 'sudo tailscale up' to join your tailnet"
 echo "  • Run 'projects' to see your cloned repos at a glance"
 echo "  • Run 'pull-all' to git pull every repo in ~/repos/"
 echo "  • Take a Proxmox snapshot of this VM (your known-good baseline)"
@@ -1368,7 +1331,7 @@ echo "  Cloud/Ops:    AWS CLI v2, Granted, Terraform, tfswitch, kubectl, eksctl,
 echo "  Containers:   Docker Engine + Compose"
 echo "  Dev tools:    git, gh, VS Code, Claude Code, jq, yq, ripgrep, fzf, bat, tmux"
 echo "  Shell:        Starship prompt, direnv, shellcheck"
-echo "  Remote:       XRDP (port 3389), SSH (port 22), Tailscale (mesh VPN)"
+echo "  Remote:       XRDP (port 3389), SSH (port 22)"
 echo "  Desktop:      KDE Plasma (X11 session for XRDP compatibility)"
 echo "  Config:       ~/.config/workstation-bootstrap/config (org: ${GITHUB_ORG:-<none>})"
 if [[ -n "${GITHUB_ORG:-}" ]]; then

--- a/setup-ubuntu-laptop.sh
+++ b/setup-ubuntu-laptop.sh
@@ -55,7 +55,6 @@
 #  13.  Quality-of-life CLI tools
 #  14.  Shell config (starship prompt, aliases, PATH wiring)
 #  15.  Laptop power management (TLP) + firmware updates (fwupd)
-#  16.  Tailscale (mesh VPN)
 #
 # Changes from Xubuntu version:
 #   - Removed: XRDP step entirely (step 15 in xubuntu)
@@ -65,6 +64,8 @@
 #   - Added: TLP + tlp-rdw with ThinkPad charge thresholds (step 15)
 #   - Added: fwupd with refresh timer enabled (step 15)
 #   - Added: Removal of power-profiles-daemon (conflicts with TLP)
+#   - Removed:  Tailscale step (WireGuard on Firewalla replaces it as the
+#               canonical home VPN; bootstrap stays out of VPN config)
 #   - Modified: Marker migration loop now also handles xubuntu/fedora markers
 #   - Modified: Starship config docker_context module retained as-is
 # ============================================================================
@@ -136,7 +137,7 @@ require() {
   fi
 }
 
-TOTAL_STEPS=16
+TOTAL_STEPS=15
 
 # --- Preflight --------------------------------------------------------------
 section "Preflight Checks"
@@ -1205,27 +1206,6 @@ fi
 sudo systemctl enable --now fwupd-refresh.timer 2>/dev/null || true
 success "fwupd ready — run 'fwupdmgr refresh && fwupdmgr update' to apply firmware."
 
-# --- 16. Tailscale (mesh VPN) ------------------------------------------------
-section "$TOTAL_STEPS/$TOTAL_STEPS — Tailscale (mesh VPN)"
-
-if ! command_exists tailscale; then
-  info "Installing Tailscale..."
-  curl -fsSL https://tailscale.com/install.sh | sh
-fi
-
-if command_exists tailscale; then
-  sudo systemctl enable --now tailscaled
-  success "Tailscale installed and service enabled."
-  if ! tailscale status &>/dev/null; then
-    info "Run 'sudo tailscale up' to authenticate and join your tailnet."
-    info "Then SSH from your Chromebook using the Tailscale IP or MagicDNS name."
-  else
-    success "Tailscale is connected: $(tailscale ip -4 2>/dev/null || echo '<run tailscale up>')"
-  fi
-else
-  warn "Tailscale install failed. Install manually: https://tailscale.com/download/linux"
-fi
-
 # ============================================================================
 section "🎉 Setup Complete!"
 echo ""
@@ -1239,7 +1219,6 @@ echo "  • Run 'docker run hello-world' to verify Docker"
 echo "  • Run 'aws configure' (or 'aws configure sso') to set up AWS creds"
 echo "  • Run 'assume <profile>' to switch AWS accounts via Granted"
 echo "  • Run 'claude' to authenticate Claude Code"
-echo "  • Run 'sudo tailscale up' to join your tailnet"
 echo "  • Run 'fwupdmgr refresh && fwupdmgr update' to apply firmware updates"
 echo "  • Run 'sudo tlp-stat -s' and 'sudo tlp-stat -b' to verify TLP"
 echo "  • Edit /etc/tlp.d/01-thinkpad-charge-thresholds.conf to change defaults"
@@ -1252,7 +1231,7 @@ echo "  Cloud/Ops:    AWS CLI v2, Granted, Terraform, tfswitch, kubectl, eksctl,
 echo "  Containers:   Docker Engine + Compose"
 echo "  Dev tools:    git, gh, VS Code, Claude Code, jq, yq, ripgrep, fzf, bat, tmux"
 echo "  Shell:        Starship prompt, direnv, shellcheck"
-echo "  Remote:       SSH (port 22), Tailscale (mesh VPN)"
+echo "  Remote:       SSH (port 22)"
 echo "  Power:        TLP (battery 75-80% on ThinkPads), fwupd (LVFS firmware)"
 echo "  Config:       ~/.config/workstation-bootstrap/config (org: ${GITHUB_ORG:-<none>})"
 if [[ -n "${GITHUB_ORG:-}" ]]; then

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -50,7 +50,6 @@
 #  13.  Quality-of-life CLI tools
 #  14.  Shell config (starship prompt, aliases, PATH wiring)
 #  15.  XRDP configuration (remote desktop from Chromebook)
-#  16.  Tailscale (mesh VPN)
 #
 # Changes from Crostini version:
 #   - Docker: full engine (docker-ce + containerd) instead of CLI-only
@@ -130,7 +129,7 @@ require() {
   fi
 }
 
-TOTAL_STEPS=16
+TOTAL_STEPS=15
 
 # --- Preflight --------------------------------------------------------------
 section "Preflight Checks"
@@ -1178,27 +1177,6 @@ sudo systemctl enable --now xrdp
 success "XRDP configured — connect via Microsoft Remote Desktop at $(hostname -I | awk '{print $1}'):3389"
 info "Recommended: set RDP client resolution to 1920x1080 (4K causes rendering issues with software GL)"
 
-# --- 16. Tailscale (mesh VPN) ------------------------------------------------
-section "$TOTAL_STEPS/$TOTAL_STEPS — Tailscale (mesh VPN)"
-
-if ! command_exists tailscale; then
-  info "Installing Tailscale..."
-  curl -fsSL https://tailscale.com/install.sh | sh
-fi
-
-if command_exists tailscale; then
-  sudo systemctl enable --now tailscaled
-  success "Tailscale installed and service enabled."
-  if ! tailscale status &>/dev/null; then
-    info "Run 'sudo tailscale up' to authenticate and join your tailnet."
-    info "Then connect via RDP from your Chromebook using the Tailscale IP."
-  else
-    success "Tailscale is connected: $(tailscale ip -4 2>/dev/null || echo '<run tailscale up>')"
-  fi
-else
-  warn "Tailscale install failed. Install manually: https://tailscale.com/download/linux"
-fi
-
 # ============================================================================
 section "🎉 Setup Complete!"
 echo ""
@@ -1212,7 +1190,6 @@ echo "  • Run 'docker run hello-world' to verify Docker"
 echo "  • Run 'aws configure' (or 'aws configure sso') to set up AWS creds"
 echo "  • Run 'assume <profile>' to switch AWS accounts via Granted"
 echo "  • Run 'claude' to authenticate Claude Code"
-echo "  • Run 'sudo tailscale up' to join your tailnet"
 echo "  • Run 'projects' to see your cloned repos at a glance"
 echo "  • Run 'pull-all' to git pull every repo in ~/repos/"
 echo "  • Take a Proxmox snapshot of this VM (your known-good baseline)"
@@ -1223,7 +1200,7 @@ echo "  Cloud/Ops:    AWS CLI v2, Granted, Terraform, tfswitch, kubectl, eksctl,
 echo "  Containers:   Docker Engine + Compose"
 echo "  Dev tools:    git, gh, VS Code, Claude Code, jq, yq, ripgrep, fzf, bat, tmux"
 echo "  Shell:        Starship prompt, direnv, shellcheck"
-echo "  Remote:       XRDP (port 3389), SSH (port 22), Tailscale (mesh VPN)"
+echo "  Remote:       XRDP (port 3389), SSH (port 22)"
 echo "  Config:       ~/.config/workstation-bootstrap/config (org: ${GITHUB_ORG:-<none>})"
 if [[ -n "${GITHUB_ORG:-}" ]]; then
   echo "  Your code:    ~/repos/ (${GITHUB_USER:-<configure gh>} + ${GITHUB_ORG} repos)"


### PR DESCRIPTION
## Summary
- WireGuard on the Firewalla Gold SE replaces Tailscale as the canonical home VPN — local control, no third-party control plane. WireGuard is a per-device manual config and intentionally stays out of bootstrap.
- Removed the Tailscale step (install + service + tailnet hint), header step listing entry, completion-banner checklist line, and `Remote:` summary entry from each script.
- Decremented `TOTAL_STEPS` per file:
  - `setup-fedora-workstation.sh`: 16 → 15
  - `setup-xubuntu-workstation.sh`: 16 → 15
  - `setup-ubuntu-laptop.sh`: 16 → 15
  - `setup-crostini-lab.sh`: no change (had no Tailscale step)
- Added a `Removed:` entry to the lineage block in `setup-ubuntu-laptop.sh` documenting the Tailscale drop.

## Test plan
- [x] `shellcheck --severity=warning setup-*.sh` — clean
- [x] `grep -i tailscale setup-*.sh` — only match is the intentional "Removed: Tailscale step" lineage comment in `setup-ubuntu-laptop.sh`
- [x] Each script's top-of-file step listing tops out at the new `TOTAL_STEPS` value
- [ ] CI: ShellCheck workflow passes
- [ ] CI: Claude Code Review workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)