### PR TITLE
Switch Claude Code install to native binary installer

### DIFF
--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -786,17 +786,24 @@ else
 fi
 
 # --- 12. Claude Code --------------------------------------------------------
+# Native binary installer (Anthropic's canonical install path as of Oct 2025).
+# The npm package now also ships a native binary rather than a Node entry —
+# but the standalone installer at ~/.local/bin/claude avoids the per-nvm-
+# version global package isolation that creates dangling references when
+# nvm switches versions or when claude self-updates.
+# Auto-update is enabled by default; set DISABLE_AUTOUPDATER=1 in the env
+# at install time to disable.
 section "12/$TOTAL_STEPS — Claude Code"
 
-if ! command_exists claude; then
-  info "Installing Claude Code..."
-  npm install -g --no-update-notifier @anthropic-ai/claude-code
+if ! command_exists claude || ! claude --version &>/dev/null; then
+  info "Installing Claude Code (native binary)..."
+  curl -fsSL https://claude.ai/install.sh | bash
 fi
 
 if command_exists claude; then
-  success "Claude Code installed. Run 'claude' to authenticate and get started."
+  success "Claude Code installed at $(which claude). Run 'claude' to authenticate."
 else
-  warn "Claude Code install failed. Try manually: npm install -g @anthropic-ai/claude-code"
+  warn "Claude Code install failed. Try manually: curl -fsSL https://claude.ai/install.sh | bash"
 fi
 
 # --- 13. Quality-of-life CLI tools ------------------------------------------

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -822,17 +822,24 @@ else
 fi
 
 # --- 12. Claude Code --------------------------------------------------------
+# Native binary installer (Anthropic's canonical install path as of Oct 2025).
+# The npm package now also ships a native binary rather than a Node entry —
+# but the standalone installer at ~/.local/bin/claude avoids the per-nvm-
+# version global package isolation that creates dangling references when
+# nvm switches versions or when claude self-updates.
+# Auto-update is enabled by default; set DISABLE_AUTOUPDATER=1 in the env
+# at install time to disable.
 section "12/$TOTAL_STEPS — Claude Code"
 
-if ! command_exists claude; then
-  info "Installing Claude Code..."
-  npm install -g --no-update-notifier @anthropic-ai/claude-code
+if ! command_exists claude || ! claude --version &>/dev/null; then
+  info "Installing Claude Code (native binary)..."
+  curl -fsSL https://claude.ai/install.sh | bash
 fi
 
 if command_exists claude; then
-  success "Claude Code installed. Run 'claude' to authenticate and get started."
+  success "Claude Code installed at $(which claude). Run 'claude' to authenticate."
 else
-  warn "Claude Code install failed. Try manually: npm install -g @anthropic-ai/claude-code"
+  warn "Claude Code install failed. Try manually: curl -fsSL https://claude.ai/install.sh | bash"
 fi
 
 # --- 13. Quality-of-life CLI tools ------------------------------------------

--- a/setup-ubuntu-laptop.sh
+++ b/setup-ubuntu-laptop.sh
@@ -792,17 +792,24 @@ else
 fi
 
 # --- 12. Claude Code --------------------------------------------------------
+# Native binary installer (Anthropic's canonical install path as of Oct 2025).
+# The npm package now also ships a native binary rather than a Node entry —
+# but the standalone installer at ~/.local/bin/claude avoids the per-nvm-
+# version global package isolation that creates dangling references when
+# nvm switches versions or when claude self-updates.
+# Auto-update is enabled by default; set DISABLE_AUTOUPDATER=1 in the env
+# at install time to disable.
 section "12/$TOTAL_STEPS — Claude Code"
 
-if ! command_exists claude; then
-  info "Installing Claude Code..."
-  npm install -g --no-update-notifier @anthropic-ai/claude-code
+if ! command_exists claude || ! claude --version &>/dev/null; then
+  info "Installing Claude Code (native binary)..."
+  curl -fsSL https://claude.ai/install.sh | bash
 fi
 
 if command_exists claude; then
-  success "Claude Code installed. Run 'claude' to authenticate and get started."
+  success "Claude Code installed at $(which claude). Run 'claude' to authenticate."
 else
-  warn "Claude Code install failed. Try manually: npm install -g @anthropic-ai/claude-code"
+  warn "Claude Code install failed. Try manually: curl -fsSL https://claude.ai/install.sh | bash"
 fi
 
 # --- 13. Quality-of-life CLI tools ------------------------------------------

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -777,17 +777,24 @@ else
 fi
 
 # --- 12. Claude Code --------------------------------------------------------
+# Native binary installer (Anthropic's canonical install path as of Oct 2025).
+# The npm package now also ships a native binary rather than a Node entry —
+# but the standalone installer at ~/.local/bin/claude avoids the per-nvm-
+# version global package isolation that creates dangling references when
+# nvm switches versions or when claude self-updates.
+# Auto-update is enabled by default; set DISABLE_AUTOUPDATER=1 in the env
+# at install time to disable.
 section "12/$TOTAL_STEPS — Claude Code"
 
-if ! command_exists claude; then
-  info "Installing Claude Code..."
-  npm install -g --no-update-notifier @anthropic-ai/claude-code
+if ! command_exists claude || ! claude --version &>/dev/null; then
+  info "Installing Claude Code (native binary)..."
+  curl -fsSL https://claude.ai/install.sh | bash
 fi
 
 if command_exists claude; then
-  success "Claude Code installed. Run 'claude' to authenticate and get started."
+  success "Claude Code installed at $(which claude). Run 'claude' to authenticate."
 else
-  warn "Claude Code install failed. Try manually: npm install -g @anthropic-ai/claude-code"
+  warn "Claude Code install failed. Try manually: curl -fsSL https://claude.ai/install.sh | bash"
 fi
 
 # --- 13. Quality-of-life CLI tools ------------------------------------------


### PR DESCRIPTION
## Summary
Step 12 now uses Anthropic's native installer (`curl -fsSL https://claude.ai/install.sh | bash`) instead of `npm install -g @anthropic-ai/claude-code`. The native installer is the canonical install path as of Oct 2025 and drops a self-contained binary at `~/.local/bin/claude`, which is already on PATH from the bootstrap preflight.

**Why:** the npm path produces two failure modes:
1. **Per-nvm-version isolation.** The npm-global binary lives under `~/.nvm/versions/node/<version>/bin/claude` and turns into a dangling reference when nvm switches versions, producing misleading bash hash-cache errors. Hit this on the T14 Gen 2 during initial setup.
2. **Mixed install state** when a user later runs `claude install` to migrate to the native binary — two install footprints, PATH ordering decides the winner, the loser leaves stale state that confuses `which`, `claude doctor`, and bash's hash table.

**Behavior change:** the idempotency guard now requires both `claude` on PATH *and* `claude --version` actually succeeding, which catches broken symlinks and stale bash-hash references that survived a shell reload — the failure mode that triggered this whole change.

**Files changed (all four scripts):**
- `setup-fedora-workstation.sh`
- `setup-xubuntu-workstation.sh`
- `setup-ubuntu-laptop.sh`
- `setup-crostini-lab.sh`

A rationale comment block was added above the step 12 section header in each script (matching the existing rationale-comment style elsewhere in the scripts).

## Test plan
- [x] `shellcheck --severity=warning setup-*.sh` — clean
- [x] `grep -i 'npm install.*claude-code' setup-*.sh` — zero matches
- [x] `grep -c 'claude.ai/install.sh' setup-*.sh` — 2 matches per script (install command + warn-fallback message)
- [ ] CI: ShellCheck workflow passes
- [ ] CI: Claude Code Review workflow passes
- [ ] Manual: re-run a bootstrap script on a machine that already has Claude installed via npm — the new check should reinstall over it via the native installer (or skip if `claude --version` succeeds against an existing install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)