### PR TITLE
Add clean-all and switch pull-all to default branch first

### DIFF
--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -1011,15 +1011,18 @@ projects() {
   echo ""
 }
 
-# Pull all repos at once
+# Pull every repo, switching to its default branch first
 pull-all() {
   local ok=0 fail=0
   for dir in ~/repos/*/; do
     if [[ -d "$dir/.git" ]]; then
-      local name
+      local name default
       name=$(basename "$dir")
-      if git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-        echo -e "\033[0;32m  ✓\033[0m $name"
+      default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
+      if [[ -n "$default" ]] \
+         && git -C "$dir" checkout --quiet "$default" 2>/dev/null \
+         && git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+        echo -e "\033[0;32m  ✓\033[0m $name ($default)"
         ((ok++)) || true
       else
         echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
@@ -1029,6 +1032,36 @@ pull-all() {
   done
   echo ""
   echo "Pulled: $ok ok, $fail need attention"
+}
+
+# Force-delete every local branch except the default, then pull
+clean-all() {
+  local ok=0 fail=0
+  for dir in ~/repos/*/; do
+    if [[ -d "$dir/.git" ]]; then
+      local name default branch removed=0
+      name=$(basename "$dir")
+      default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
+      if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
+        echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+        ((fail++)) || true
+        continue
+      fi
+      while IFS= read -r branch; do
+        [[ -z "$branch" || "$branch" == "$default" ]] && continue
+        git -C "$dir" branch -D "$branch" >/dev/null 2>&1 && ((removed++)) || true
+      done < <(git -C "$dir" branch --format='%(refname:short)')
+      if git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+        echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed)"
+        ((ok++)) || true
+      else
+        echo -e "\033[1;33m  ⚠ $name ($default, removed $removed, pull failed)\033[0m"
+        ((fail++)) || true
+      fi
+    fi
+  done
+  echo ""
+  echo "Cleaned: $ok ok, $fail need attention"
 }
 
 # <<< setup-crostini-lab <<<
@@ -1181,7 +1214,8 @@ echo "  • Run 'assume <profile>' to switch AWS accounts via Granted"
 echo "  • Set DOCKER_HOST in ~/.bashrc if using a remote Docker daemon"
 echo "  • Run 'claude' to authenticate Claude Code"
 echo "  • Run 'projects' to see your cloned repos at a glance"
-echo "  • Run 'pull-all' to git pull every repo in ~/repos/"
+echo "  • Run 'pull-all' to checkout default + git pull every repo in ~/repos/"
+echo "  • Run 'clean-all' to delete non-default local branches + pull every repo"
 echo ""
 echo -e "${BLUE}Installed tools summary:${NC}"
 echo "  Languages:    Python 3, Node.js (nvm), Go, Bash"

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -1029,15 +1029,18 @@ projects() {
   echo ""
 }
 
-# Pull all repos at once
+# Pull every repo, switching to its default branch first
 pull-all() {
   local ok=0 fail=0
   for dir in ~/repos/*/; do
     if [[ -d "$dir/.git" ]]; then
-      local name
+      local name default
       name=$(basename "$dir")
-      if git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-        echo -e "\033[0;32m  ✓\033[0m $name"
+      default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
+      if [[ -n "$default" ]] \
+         && git -C "$dir" checkout --quiet "$default" 2>/dev/null \
+         && git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+        echo -e "\033[0;32m  ✓\033[0m $name ($default)"
         ((ok++)) || true
       else
         echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
@@ -1047,6 +1050,36 @@ pull-all() {
   done
   echo ""
   echo "Pulled: $ok ok, $fail need attention"
+}
+
+# Force-delete every local branch except the default, then pull
+clean-all() {
+  local ok=0 fail=0
+  for dir in ~/repos/*/; do
+    if [[ -d "$dir/.git" ]]; then
+      local name default branch removed=0
+      name=$(basename "$dir")
+      default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
+      if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
+        echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+        ((fail++)) || true
+        continue
+      fi
+      while IFS= read -r branch; do
+        [[ -z "$branch" || "$branch" == "$default" ]] && continue
+        git -C "$dir" branch -D "$branch" >/dev/null 2>&1 && ((removed++)) || true
+      done < <(git -C "$dir" branch --format='%(refname:short)')
+      if git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+        echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed)"
+        ((ok++)) || true
+      else
+        echo -e "\033[1;33m  ⚠ $name ($default, removed $removed, pull failed)\033[0m"
+        ((fail++)) || true
+      fi
+    fi
+  done
+  echo ""
+  echo "Cleaned: $ok ok, $fail need attention"
 }
 
 # <<< setup-fedora-workstation <<<
@@ -1329,7 +1362,8 @@ echo "  • Run 'aws configure' (or 'aws configure sso') to set up AWS creds"
 echo "  • Run 'assume <profile>' to switch AWS accounts via Granted"
 echo "  • Run 'claude' to authenticate Claude Code"
 echo "  • Run 'projects' to see your cloned repos at a glance"
-echo "  • Run 'pull-all' to git pull every repo in ~/repos/"
+echo "  • Run 'pull-all' to checkout default + git pull every repo in ~/repos/"
+echo "  • Run 'clean-all' to delete non-default local branches + pull every repo"
 echo "  • Take a Proxmox snapshot of this VM (your known-good baseline)"
 echo ""
 echo -e "${BLUE}Installed tools summary:${NC}"

--- a/setup-ubuntu-laptop.sh
+++ b/setup-ubuntu-laptop.sh
@@ -1016,15 +1016,18 @@ projects() {
   echo ""
 }
 
-# Pull all repos at once
+# Pull every repo, switching to its default branch first
 pull-all() {
   local ok=0 fail=0
   for dir in ~/repos/*/; do
     if [[ -d "$dir/.git" ]]; then
-      local name
+      local name default
       name=$(basename "$dir")
-      if git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-        echo -e "\033[0;32m  ✓\033[0m $name"
+      default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
+      if [[ -n "$default" ]] \
+         && git -C "$dir" checkout --quiet "$default" 2>/dev/null \
+         && git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+        echo -e "\033[0;32m  ✓\033[0m $name ($default)"
         ((ok++)) || true
       else
         echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
@@ -1034,6 +1037,36 @@ pull-all() {
   done
   echo ""
   echo "Pulled: $ok ok, $fail need attention"
+}
+
+# Force-delete every local branch except the default, then pull
+clean-all() {
+  local ok=0 fail=0
+  for dir in ~/repos/*/; do
+    if [[ -d "$dir/.git" ]]; then
+      local name default branch removed=0
+      name=$(basename "$dir")
+      default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
+      if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
+        echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+        ((fail++)) || true
+        continue
+      fi
+      while IFS= read -r branch; do
+        [[ -z "$branch" || "$branch" == "$default" ]] && continue
+        git -C "$dir" branch -D "$branch" >/dev/null 2>&1 && ((removed++)) || true
+      done < <(git -C "$dir" branch --format='%(refname:short)')
+      if git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+        echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed)"
+        ((ok++)) || true
+      else
+        echo -e "\033[1;33m  ⚠ $name ($default, removed $removed, pull failed)\033[0m"
+        ((fail++)) || true
+      fi
+    fi
+  done
+  echo ""
+  echo "Cleaned: $ok ok, $fail need attention"
 }
 
 # <<< setup-ubuntu-laptop <<<
@@ -1230,7 +1263,8 @@ echo "  • Run 'fwupdmgr refresh && fwupdmgr update' to apply firmware updates"
 echo "  • Run 'sudo tlp-stat -s' and 'sudo tlp-stat -b' to verify TLP"
 echo "  • Edit /etc/tlp.d/01-thinkpad-charge-thresholds.conf to change defaults"
 echo "  • Run 'projects' to see your cloned repos at a glance"
-echo "  • Run 'pull-all' to git pull every repo in ~/repos/"
+echo "  • Run 'pull-all' to checkout default + git pull every repo in ~/repos/"
+echo "  • Run 'clean-all' to delete non-default local branches + pull every repo"
 echo ""
 echo -e "${BLUE}Installed tools summary:${NC}"
 echo "  Languages:    Python 3, Node.js (nvm), Go, Bash"

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -995,15 +995,18 @@ projects() {
   echo ""
 }
 
-# Pull all repos at once
+# Pull every repo, switching to its default branch first
 pull-all() {
   local ok=0 fail=0
   for dir in ~/repos/*/; do
     if [[ -d "$dir/.git" ]]; then
-      local name
+      local name default
       name=$(basename "$dir")
-      if git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-        echo -e "\033[0;32m  ✓\033[0m $name"
+      default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
+      if [[ -n "$default" ]] \
+         && git -C "$dir" checkout --quiet "$default" 2>/dev/null \
+         && git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+        echo -e "\033[0;32m  ✓\033[0m $name ($default)"
         ((ok++)) || true
       else
         echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
@@ -1013,6 +1016,36 @@ pull-all() {
   done
   echo ""
   echo "Pulled: $ok ok, $fail need attention"
+}
+
+# Force-delete every local branch except the default, then pull
+clean-all() {
+  local ok=0 fail=0
+  for dir in ~/repos/*/; do
+    if [[ -d "$dir/.git" ]]; then
+      local name default branch removed=0
+      name=$(basename "$dir")
+      default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
+      if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
+        echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+        ((fail++)) || true
+        continue
+      fi
+      while IFS= read -r branch; do
+        [[ -z "$branch" || "$branch" == "$default" ]] && continue
+        git -C "$dir" branch -D "$branch" >/dev/null 2>&1 && ((removed++)) || true
+      done < <(git -C "$dir" branch --format='%(refname:short)')
+      if git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+        echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed)"
+        ((ok++)) || true
+      else
+        echo -e "\033[1;33m  ⚠ $name ($default, removed $removed, pull failed)\033[0m"
+        ((fail++)) || true
+      fi
+    fi
+  done
+  echo ""
+  echo "Cleaned: $ok ok, $fail need attention"
 }
 
 # <<< setup-xubuntu-workstation <<<
@@ -1198,7 +1231,8 @@ echo "  • Run 'aws configure' (or 'aws configure sso') to set up AWS creds"
 echo "  • Run 'assume <profile>' to switch AWS accounts via Granted"
 echo "  • Run 'claude' to authenticate Claude Code"
 echo "  • Run 'projects' to see your cloned repos at a glance"
-echo "  • Run 'pull-all' to git pull every repo in ~/repos/"
+echo "  • Run 'pull-all' to checkout default + git pull every repo in ~/repos/"
+echo "  • Run 'clean-all' to delete non-default local branches + pull every repo"
 echo "  • Take a Proxmox snapshot of this VM (your known-good baseline)"
 echo ""
 echo -e "${BLUE}Installed tools summary:${NC}"


### PR DESCRIPTION
## Summary
- `pull-all` now resolves each repo's default branch via `origin/HEAD`, checks it out, then `pull --rebase`. Previously it just pulled whatever branch was checked out, which was wrong if you'd left a feature branch behind.
- New `clean-all` does the same default-branch checkout, force-deletes every other local branch (`git branch -D`), then pulls. Useful for clearing out stale branches across `~/repos/` after a flurry of PR merges.
- Post-install checklist updated in all four scripts.

Applied identically to all four bootstrap scripts (crostini, xubuntu, fedora, ubuntu-laptop) per the in-sync rule in CLAUDE.md.

## Test plan
- [ ] `shellcheck --severity=warning` clean on all four scripts (verified locally)
- [ ] Run `pull-all` in a workstation with a mix of repos on default and feature branches — confirm each switches to default and rebases
- [ ] Run `clean-all` in a repo with several stale local branches — confirm only the default survives and a pull runs
- [ ] Run on a repo with a dirty worktree — confirm it falls into the warn path rather than corrupting state
- [ ] Run on a repo whose `origin/HEAD` is unset — confirm it warns instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)