### PR TITLE
Show diffstat of pulled changes in pull-all and clean-all

### DIFF
--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -1013,55 +1013,72 @@ projects() {
 
 # Pull every repo, switching to its default branch first
 pull-all() {
-  local ok=0 fail=0
+  local ok=0 fail=0 unchanged=0
   for dir in ~/repos/*/; do
-    if [[ -d "$dir/.git" ]]; then
-      local name default
-      name=$(basename "$dir")
-      default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
-      if [[ -n "$default" ]] \
-         && git -C "$dir" checkout --quiet "$default" 2>/dev/null \
-         && git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-        echo -e "\033[0;32m  ✓\033[0m $name ($default)"
-        ((ok++)) || true
-      else
-        echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-        ((fail++)) || true
-      fi
+    [[ -d "$dir/.git" ]] || continue
+    local name default before after
+    name=$(basename "$dir")
+    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
+    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
+      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+      ((fail++)) || true
+      continue
+    fi
+    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
+    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+      ((fail++)) || true
+      continue
+    fi
+    after=$(git -C "$dir" rev-parse HEAD)
+    if [[ "$before" == "$after" ]]; then
+      echo -e "\033[0;32m  ✓\033[0m $name ($default, up to date)"
+      ((unchanged++)) || true
+    else
+      echo -e "\033[0;32m  ✓\033[0m $name ($default)"
+      git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
+      ((ok++)) || true
     fi
   done
   echo ""
-  echo "Pulled: $ok ok, $fail need attention"
+  echo "Pulled: $ok updated, $unchanged unchanged, $fail need attention"
 }
 
 # Force-delete every local branch except the default, then pull
 clean-all() {
-  local ok=0 fail=0
+  local ok=0 fail=0 unchanged=0
   for dir in ~/repos/*/; do
-    if [[ -d "$dir/.git" ]]; then
-      local name default branch removed=0
-      name=$(basename "$dir")
-      default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
-      if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
-        echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-        ((fail++)) || true
-        continue
-      fi
-      while IFS= read -r branch; do
-        [[ -z "$branch" || "$branch" == "$default" ]] && continue
-        git -C "$dir" branch -D "$branch" >/dev/null 2>&1 && ((removed++)) || true
-      done < <(git -C "$dir" branch --format='%(refname:short)')
-      if git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-        echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed)"
-        ((ok++)) || true
-      else
-        echo -e "\033[1;33m  ⚠ $name ($default, removed $removed, pull failed)\033[0m"
-        ((fail++)) || true
-      fi
+    [[ -d "$dir/.git" ]] || continue
+    local name default branch before after removed=0
+    name=$(basename "$dir")
+    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
+    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
+      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+      ((fail++)) || true
+      continue
+    fi
+    while IFS= read -r branch; do
+      [[ -z "$branch" || "$branch" == "$default" ]] && continue
+      git -C "$dir" branch -D "$branch" >/dev/null 2>&1 && ((removed++)) || true
+    done < <(git -C "$dir" branch --format='%(refname:short)')
+    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
+    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+      echo -e "\033[1;33m  ⚠ $name ($default, removed $removed, pull failed)\033[0m"
+      ((fail++)) || true
+      continue
+    fi
+    after=$(git -C "$dir" rev-parse HEAD)
+    if [[ "$before" == "$after" ]]; then
+      echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed, up to date)"
+      ((unchanged++)) || true
+    else
+      echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed)"
+      git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
+      ((ok++)) || true
     fi
   done
   echo ""
-  echo "Cleaned: $ok ok, $fail need attention"
+  echo "Cleaned: $ok updated, $unchanged unchanged, $fail need attention"
 }
 
 # <<< setup-crostini-lab <<<

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -1031,55 +1031,72 @@ projects() {
 
 # Pull every repo, switching to its default branch first
 pull-all() {
-  local ok=0 fail=0
+  local ok=0 fail=0 unchanged=0
   for dir in ~/repos/*/; do
-    if [[ -d "$dir/.git" ]]; then
-      local name default
-      name=$(basename "$dir")
-      default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
-      if [[ -n "$default" ]] \
-         && git -C "$dir" checkout --quiet "$default" 2>/dev/null \
-         && git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-        echo -e "\033[0;32m  ✓\033[0m $name ($default)"
-        ((ok++)) || true
-      else
-        echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-        ((fail++)) || true
-      fi
+    [[ -d "$dir/.git" ]] || continue
+    local name default before after
+    name=$(basename "$dir")
+    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
+    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
+      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+      ((fail++)) || true
+      continue
+    fi
+    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
+    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+      ((fail++)) || true
+      continue
+    fi
+    after=$(git -C "$dir" rev-parse HEAD)
+    if [[ "$before" == "$after" ]]; then
+      echo -e "\033[0;32m  ✓\033[0m $name ($default, up to date)"
+      ((unchanged++)) || true
+    else
+      echo -e "\033[0;32m  ✓\033[0m $name ($default)"
+      git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
+      ((ok++)) || true
     fi
   done
   echo ""
-  echo "Pulled: $ok ok, $fail need attention"
+  echo "Pulled: $ok updated, $unchanged unchanged, $fail need attention"
 }
 
 # Force-delete every local branch except the default, then pull
 clean-all() {
-  local ok=0 fail=0
+  local ok=0 fail=0 unchanged=0
   for dir in ~/repos/*/; do
-    if [[ -d "$dir/.git" ]]; then
-      local name default branch removed=0
-      name=$(basename "$dir")
-      default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
-      if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
-        echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-        ((fail++)) || true
-        continue
-      fi
-      while IFS= read -r branch; do
-        [[ -z "$branch" || "$branch" == "$default" ]] && continue
-        git -C "$dir" branch -D "$branch" >/dev/null 2>&1 && ((removed++)) || true
-      done < <(git -C "$dir" branch --format='%(refname:short)')
-      if git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-        echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed)"
-        ((ok++)) || true
-      else
-        echo -e "\033[1;33m  ⚠ $name ($default, removed $removed, pull failed)\033[0m"
-        ((fail++)) || true
-      fi
+    [[ -d "$dir/.git" ]] || continue
+    local name default branch before after removed=0
+    name=$(basename "$dir")
+    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
+    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
+      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+      ((fail++)) || true
+      continue
+    fi
+    while IFS= read -r branch; do
+      [[ -z "$branch" || "$branch" == "$default" ]] && continue
+      git -C "$dir" branch -D "$branch" >/dev/null 2>&1 && ((removed++)) || true
+    done < <(git -C "$dir" branch --format='%(refname:short)')
+    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
+    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+      echo -e "\033[1;33m  ⚠ $name ($default, removed $removed, pull failed)\033[0m"
+      ((fail++)) || true
+      continue
+    fi
+    after=$(git -C "$dir" rev-parse HEAD)
+    if [[ "$before" == "$after" ]]; then
+      echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed, up to date)"
+      ((unchanged++)) || true
+    else
+      echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed)"
+      git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
+      ((ok++)) || true
     fi
   done
   echo ""
-  echo "Cleaned: $ok ok, $fail need attention"
+  echo "Cleaned: $ok updated, $unchanged unchanged, $fail need attention"
 }
 
 # <<< setup-fedora-workstation <<<

--- a/setup-ubuntu-laptop.sh
+++ b/setup-ubuntu-laptop.sh
@@ -1018,55 +1018,72 @@ projects() {
 
 # Pull every repo, switching to its default branch first
 pull-all() {
-  local ok=0 fail=0
+  local ok=0 fail=0 unchanged=0
   for dir in ~/repos/*/; do
-    if [[ -d "$dir/.git" ]]; then
-      local name default
-      name=$(basename "$dir")
-      default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
-      if [[ -n "$default" ]] \
-         && git -C "$dir" checkout --quiet "$default" 2>/dev/null \
-         && git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-        echo -e "\033[0;32m  ✓\033[0m $name ($default)"
-        ((ok++)) || true
-      else
-        echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-        ((fail++)) || true
-      fi
+    [[ -d "$dir/.git" ]] || continue
+    local name default before after
+    name=$(basename "$dir")
+    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
+    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
+      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+      ((fail++)) || true
+      continue
+    fi
+    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
+    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+      ((fail++)) || true
+      continue
+    fi
+    after=$(git -C "$dir" rev-parse HEAD)
+    if [[ "$before" == "$after" ]]; then
+      echo -e "\033[0;32m  ✓\033[0m $name ($default, up to date)"
+      ((unchanged++)) || true
+    else
+      echo -e "\033[0;32m  ✓\033[0m $name ($default)"
+      git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
+      ((ok++)) || true
     fi
   done
   echo ""
-  echo "Pulled: $ok ok, $fail need attention"
+  echo "Pulled: $ok updated, $unchanged unchanged, $fail need attention"
 }
 
 # Force-delete every local branch except the default, then pull
 clean-all() {
-  local ok=0 fail=0
+  local ok=0 fail=0 unchanged=0
   for dir in ~/repos/*/; do
-    if [[ -d "$dir/.git" ]]; then
-      local name default branch removed=0
-      name=$(basename "$dir")
-      default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
-      if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
-        echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-        ((fail++)) || true
-        continue
-      fi
-      while IFS= read -r branch; do
-        [[ -z "$branch" || "$branch" == "$default" ]] && continue
-        git -C "$dir" branch -D "$branch" >/dev/null 2>&1 && ((removed++)) || true
-      done < <(git -C "$dir" branch --format='%(refname:short)')
-      if git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-        echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed)"
-        ((ok++)) || true
-      else
-        echo -e "\033[1;33m  ⚠ $name ($default, removed $removed, pull failed)\033[0m"
-        ((fail++)) || true
-      fi
+    [[ -d "$dir/.git" ]] || continue
+    local name default branch before after removed=0
+    name=$(basename "$dir")
+    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
+    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
+      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+      ((fail++)) || true
+      continue
+    fi
+    while IFS= read -r branch; do
+      [[ -z "$branch" || "$branch" == "$default" ]] && continue
+      git -C "$dir" branch -D "$branch" >/dev/null 2>&1 && ((removed++)) || true
+    done < <(git -C "$dir" branch --format='%(refname:short)')
+    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
+    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+      echo -e "\033[1;33m  ⚠ $name ($default, removed $removed, pull failed)\033[0m"
+      ((fail++)) || true
+      continue
+    fi
+    after=$(git -C "$dir" rev-parse HEAD)
+    if [[ "$before" == "$after" ]]; then
+      echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed, up to date)"
+      ((unchanged++)) || true
+    else
+      echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed)"
+      git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
+      ((ok++)) || true
     fi
   done
   echo ""
-  echo "Cleaned: $ok ok, $fail need attention"
+  echo "Cleaned: $ok updated, $unchanged unchanged, $fail need attention"
 }
 
 # <<< setup-ubuntu-laptop <<<

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -997,55 +997,72 @@ projects() {
 
 # Pull every repo, switching to its default branch first
 pull-all() {
-  local ok=0 fail=0
+  local ok=0 fail=0 unchanged=0
   for dir in ~/repos/*/; do
-    if [[ -d "$dir/.git" ]]; then
-      local name default
-      name=$(basename "$dir")
-      default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
-      if [[ -n "$default" ]] \
-         && git -C "$dir" checkout --quiet "$default" 2>/dev/null \
-         && git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-        echo -e "\033[0;32m  ✓\033[0m $name ($default)"
-        ((ok++)) || true
-      else
-        echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-        ((fail++)) || true
-      fi
+    [[ -d "$dir/.git" ]] || continue
+    local name default before after
+    name=$(basename "$dir")
+    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
+    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
+      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+      ((fail++)) || true
+      continue
+    fi
+    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
+    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+      ((fail++)) || true
+      continue
+    fi
+    after=$(git -C "$dir" rev-parse HEAD)
+    if [[ "$before" == "$after" ]]; then
+      echo -e "\033[0;32m  ✓\033[0m $name ($default, up to date)"
+      ((unchanged++)) || true
+    else
+      echo -e "\033[0;32m  ✓\033[0m $name ($default)"
+      git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
+      ((ok++)) || true
     fi
   done
   echo ""
-  echo "Pulled: $ok ok, $fail need attention"
+  echo "Pulled: $ok updated, $unchanged unchanged, $fail need attention"
 }
 
 # Force-delete every local branch except the default, then pull
 clean-all() {
-  local ok=0 fail=0
+  local ok=0 fail=0 unchanged=0
   for dir in ~/repos/*/; do
-    if [[ -d "$dir/.git" ]]; then
-      local name default branch removed=0
-      name=$(basename "$dir")
-      default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
-      if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
-        echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-        ((fail++)) || true
-        continue
-      fi
-      while IFS= read -r branch; do
-        [[ -z "$branch" || "$branch" == "$default" ]] && continue
-        git -C "$dir" branch -D "$branch" >/dev/null 2>&1 && ((removed++)) || true
-      done < <(git -C "$dir" branch --format='%(refname:short)')
-      if git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-        echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed)"
-        ((ok++)) || true
-      else
-        echo -e "\033[1;33m  ⚠ $name ($default, removed $removed, pull failed)\033[0m"
-        ((fail++)) || true
-      fi
+    [[ -d "$dir/.git" ]] || continue
+    local name default branch before after removed=0
+    name=$(basename "$dir")
+    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
+    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
+      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
+      ((fail++)) || true
+      continue
+    fi
+    while IFS= read -r branch; do
+      [[ -z "$branch" || "$branch" == "$default" ]] && continue
+      git -C "$dir" branch -D "$branch" >/dev/null 2>&1 && ((removed++)) || true
+    done < <(git -C "$dir" branch --format='%(refname:short)')
+    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
+    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+      echo -e "\033[1;33m  ⚠ $name ($default, removed $removed, pull failed)\033[0m"
+      ((fail++)) || true
+      continue
+    fi
+    after=$(git -C "$dir" rev-parse HEAD)
+    if [[ "$before" == "$after" ]]; then
+      echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed, up to date)"
+      ((unchanged++)) || true
+    else
+      echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed)"
+      git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
+      ((ok++)) || true
     fi
   done
   echo ""
-  echo "Cleaned: $ok ok, $fail need attention"
+  echo "Cleaned: $ok updated, $unchanged unchanged, $fail need attention"
 }
 
 # <<< setup-xubuntu-workstation <<<


### PR DESCRIPTION
## Summary
- `pull-all` and `clean-all` now capture HEAD before and after the pull, then print `git diff --stat` (indented) when the SHA moved.
- Trailing summary now reports `N updated, N unchanged, N need attention` so a no-op multi-repo pull is obvious at a glance.

## Test plan
- [ ] Source the updated `.bashrc` block on a workstation, run `pull-all` against `~/repos/` containing a mix of up-to-date repos and ones with upstream changes — confirm diffstat appears only for repos that moved and the summary tallies match.
- [ ] Same check for `clean-all`, including a repo with extra local branches to verify the `removed N` count and that the diffstat still appears post-deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)