### PR TITLE
Move pull-all and clean-all from .bashrc functions to scripts/

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,3 +45,5 @@ The next bootstrap run on any workstation will symlink it into `~/.local/bin/`.
 | Tool | Description |
 |---|---|
 | `gh-issue` | Create GitHub issues without shell-escape drama; see the script header for full usage. |
+| `pull-all` | Switch every repo under `~/repos` to its default branch and pull, with a per-repo diffstat. |
+| `clean-all` | Force-delete every non-default local branch in each repo under `~/repos`, then pull. |

--- a/scripts/clean-all
+++ b/scripts/clean-all
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# clean-all — Force-delete every local branch except the default in each
+# repo under ~/repos, then pull. Useful after a wave of merged PRs.
+# Dependencies: git
+# Usage: clean-all
+#   REPOS_DIR   override the directory to scan (default: ~/repos)
+set -euo pipefail
+
+REPOS_DIR="${REPOS_DIR:-$HOME/repos}"
+
+ok=0
+unchanged=0
+fail=0
+
+for dir in "$REPOS_DIR"/*/; do
+    [[ -d "$dir/.git" ]] || continue
+    name=$(basename "$dir")
+
+    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||' || true)
+    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
+        printf '\033[1;33m  ⚠ %s (check manually)\033[0m\n' "$name"
+        fail=$((fail + 1))
+        continue
+    fi
+
+    removed=0
+    while IFS= read -r branch; do
+        [[ -z "$branch" || "$branch" == "$default" ]] && continue
+        if git -C "$dir" branch -D "$branch" >/dev/null 2>&1; then
+            removed=$((removed + 1))
+        fi
+    done < <(git -C "$dir" branch --format='%(refname:short)')
+
+    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
+    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+        printf '\033[1;33m  ⚠ %s (%s, removed %d, pull failed)\033[0m\n' "$name" "$default" "$removed"
+        fail=$((fail + 1))
+        continue
+    fi
+    after=$(git -C "$dir" rev-parse HEAD)
+
+    if [[ "$before" == "$after" ]]; then
+        printf '\033[0;32m  ✓\033[0m %s (%s, removed %d, up to date)\n' "$name" "$default" "$removed"
+        unchanged=$((unchanged + 1))
+    else
+        printf '\033[0;32m  ✓\033[0m %s (%s, removed %d)\n' "$name" "$default" "$removed"
+        git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
+        ok=$((ok + 1))
+    fi
+done
+
+echo ""
+echo "Cleaned: $ok updated, $unchanged unchanged, $fail need attention"

--- a/scripts/pull-all
+++ b/scripts/pull-all
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# pull-all — Switch every repo under ~/repos to its default branch and pull.
+# Dependencies: git
+# Usage: pull-all
+#   REPOS_DIR   override the directory to scan (default: ~/repos)
+set -euo pipefail
+
+REPOS_DIR="${REPOS_DIR:-$HOME/repos}"
+
+ok=0
+unchanged=0
+fail=0
+
+for dir in "$REPOS_DIR"/*/; do
+    [[ -d "$dir/.git" ]] || continue
+    name=$(basename "$dir")
+
+    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||' || true)
+    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
+        printf '\033[1;33m  ⚠ %s (check manually)\033[0m\n' "$name"
+        fail=$((fail + 1))
+        continue
+    fi
+
+    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
+    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
+        printf '\033[1;33m  ⚠ %s (check manually)\033[0m\n' "$name"
+        fail=$((fail + 1))
+        continue
+    fi
+    after=$(git -C "$dir" rev-parse HEAD)
+
+    if [[ "$before" == "$after" ]]; then
+        printf '\033[0;32m  ✓\033[0m %s (%s, up to date)\n' "$name" "$default"
+        unchanged=$((unchanged + 1))
+    else
+        printf '\033[0;32m  ✓\033[0m %s (%s)\n' "$name" "$default"
+        git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
+        ok=$((ok + 1))
+    fi
+done
+
+echo ""
+echo "Pulled: $ok updated, $unchanged unchanged, $fail need attention"

--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -1011,75 +1011,8 @@ projects() {
   echo ""
 }
 
-# Pull every repo, switching to its default branch first
-pull-all() {
-  local ok=0 fail=0 unchanged=0
-  for dir in ~/repos/*/; do
-    [[ -d "$dir/.git" ]] || continue
-    local name default before after
-    name=$(basename "$dir")
-    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
-    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
-      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-      ((fail++)) || true
-      continue
-    fi
-    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
-    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-      ((fail++)) || true
-      continue
-    fi
-    after=$(git -C "$dir" rev-parse HEAD)
-    if [[ "$before" == "$after" ]]; then
-      echo -e "\033[0;32m  ✓\033[0m $name ($default, up to date)"
-      ((unchanged++)) || true
-    else
-      echo -e "\033[0;32m  ✓\033[0m $name ($default)"
-      git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
-      ((ok++)) || true
-    fi
-  done
-  echo ""
-  echo "Pulled: $ok updated, $unchanged unchanged, $fail need attention"
-}
-
-# Force-delete every local branch except the default, then pull
-clean-all() {
-  local ok=0 fail=0 unchanged=0
-  for dir in ~/repos/*/; do
-    [[ -d "$dir/.git" ]] || continue
-    local name default branch before after removed=0
-    name=$(basename "$dir")
-    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
-    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
-      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-      ((fail++)) || true
-      continue
-    fi
-    while IFS= read -r branch; do
-      [[ -z "$branch" || "$branch" == "$default" ]] && continue
-      git -C "$dir" branch -D "$branch" >/dev/null 2>&1 && ((removed++)) || true
-    done < <(git -C "$dir" branch --format='%(refname:short)')
-    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
-    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-      echo -e "\033[1;33m  ⚠ $name ($default, removed $removed, pull failed)\033[0m"
-      ((fail++)) || true
-      continue
-    fi
-    after=$(git -C "$dir" rev-parse HEAD)
-    if [[ "$before" == "$after" ]]; then
-      echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed, up to date)"
-      ((unchanged++)) || true
-    else
-      echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed)"
-      git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
-      ((ok++)) || true
-    fi
-  done
-  echo ""
-  echo "Cleaned: $ok updated, $unchanged unchanged, $fail need attention"
-}
+# pull-all and clean-all live in scripts/ and are symlinked into
+# ~/.local/bin by bootstrap/install-scripts.sh.
 
 # <<< setup-crostini-lab <<<
 BASHRC_BLOCK

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -1029,75 +1029,8 @@ projects() {
   echo ""
 }
 
-# Pull every repo, switching to its default branch first
-pull-all() {
-  local ok=0 fail=0 unchanged=0
-  for dir in ~/repos/*/; do
-    [[ -d "$dir/.git" ]] || continue
-    local name default before after
-    name=$(basename "$dir")
-    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
-    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
-      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-      ((fail++)) || true
-      continue
-    fi
-    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
-    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-      ((fail++)) || true
-      continue
-    fi
-    after=$(git -C "$dir" rev-parse HEAD)
-    if [[ "$before" == "$after" ]]; then
-      echo -e "\033[0;32m  ✓\033[0m $name ($default, up to date)"
-      ((unchanged++)) || true
-    else
-      echo -e "\033[0;32m  ✓\033[0m $name ($default)"
-      git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
-      ((ok++)) || true
-    fi
-  done
-  echo ""
-  echo "Pulled: $ok updated, $unchanged unchanged, $fail need attention"
-}
-
-# Force-delete every local branch except the default, then pull
-clean-all() {
-  local ok=0 fail=0 unchanged=0
-  for dir in ~/repos/*/; do
-    [[ -d "$dir/.git" ]] || continue
-    local name default branch before after removed=0
-    name=$(basename "$dir")
-    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
-    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
-      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-      ((fail++)) || true
-      continue
-    fi
-    while IFS= read -r branch; do
-      [[ -z "$branch" || "$branch" == "$default" ]] && continue
-      git -C "$dir" branch -D "$branch" >/dev/null 2>&1 && ((removed++)) || true
-    done < <(git -C "$dir" branch --format='%(refname:short)')
-    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
-    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-      echo -e "\033[1;33m  ⚠ $name ($default, removed $removed, pull failed)\033[0m"
-      ((fail++)) || true
-      continue
-    fi
-    after=$(git -C "$dir" rev-parse HEAD)
-    if [[ "$before" == "$after" ]]; then
-      echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed, up to date)"
-      ((unchanged++)) || true
-    else
-      echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed)"
-      git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
-      ((ok++)) || true
-    fi
-  done
-  echo ""
-  echo "Cleaned: $ok updated, $unchanged unchanged, $fail need attention"
-}
+# pull-all and clean-all live in scripts/ and are symlinked into
+# ~/.local/bin by bootstrap/install-scripts.sh.
 
 # <<< setup-fedora-workstation <<<
 BASHRC_BLOCK

--- a/setup-ubuntu-laptop.sh
+++ b/setup-ubuntu-laptop.sh
@@ -137,7 +137,7 @@ require() {
   fi
 }
 
-TOTAL_STEPS=15
+TOTAL_STEPS=16
 
 # --- Preflight --------------------------------------------------------------
 section "Preflight Checks"
@@ -1016,75 +1016,8 @@ projects() {
   echo ""
 }
 
-# Pull every repo, switching to its default branch first
-pull-all() {
-  local ok=0 fail=0 unchanged=0
-  for dir in ~/repos/*/; do
-    [[ -d "$dir/.git" ]] || continue
-    local name default before after
-    name=$(basename "$dir")
-    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
-    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
-      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-      ((fail++)) || true
-      continue
-    fi
-    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
-    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-      ((fail++)) || true
-      continue
-    fi
-    after=$(git -C "$dir" rev-parse HEAD)
-    if [[ "$before" == "$after" ]]; then
-      echo -e "\033[0;32m  ✓\033[0m $name ($default, up to date)"
-      ((unchanged++)) || true
-    else
-      echo -e "\033[0;32m  ✓\033[0m $name ($default)"
-      git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
-      ((ok++)) || true
-    fi
-  done
-  echo ""
-  echo "Pulled: $ok updated, $unchanged unchanged, $fail need attention"
-}
-
-# Force-delete every local branch except the default, then pull
-clean-all() {
-  local ok=0 fail=0 unchanged=0
-  for dir in ~/repos/*/; do
-    [[ -d "$dir/.git" ]] || continue
-    local name default branch before after removed=0
-    name=$(basename "$dir")
-    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
-    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
-      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-      ((fail++)) || true
-      continue
-    fi
-    while IFS= read -r branch; do
-      [[ -z "$branch" || "$branch" == "$default" ]] && continue
-      git -C "$dir" branch -D "$branch" >/dev/null 2>&1 && ((removed++)) || true
-    done < <(git -C "$dir" branch --format='%(refname:short)')
-    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
-    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-      echo -e "\033[1;33m  ⚠ $name ($default, removed $removed, pull failed)\033[0m"
-      ((fail++)) || true
-      continue
-    fi
-    after=$(git -C "$dir" rev-parse HEAD)
-    if [[ "$before" == "$after" ]]; then
-      echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed, up to date)"
-      ((unchanged++)) || true
-    else
-      echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed)"
-      git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
-      ((ok++)) || true
-    fi
-  done
-  echo ""
-  echo "Cleaned: $ok updated, $unchanged unchanged, $fail need attention"
-}
+# pull-all and clean-all live in scripts/ and are symlinked into
+# ~/.local/bin by bootstrap/install-scripts.sh.
 
 # <<< setup-ubuntu-laptop <<<
 BASHRC_BLOCK
@@ -1262,6 +1195,12 @@ if ! command_exists fwupdmgr; then
 fi
 sudo systemctl enable --now fwupd-refresh.timer 2>/dev/null || true
 success "fwupd ready — run 'fwupdmgr refresh && fwupdmgr update' to apply firmware."
+
+# --- 16. Install scripts into ~/.local/bin ----------------------------------
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+section "16/$TOTAL_STEPS — Installing Scripts into ~/.local/bin"
+bash "$SCRIPT_DIR/bootstrap/install-scripts.sh"
+success "Scripts installed."
 
 # ============================================================================
 section "🎉 Setup Complete!"

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -995,75 +995,8 @@ projects() {
   echo ""
 }
 
-# Pull every repo, switching to its default branch first
-pull-all() {
-  local ok=0 fail=0 unchanged=0
-  for dir in ~/repos/*/; do
-    [[ -d "$dir/.git" ]] || continue
-    local name default before after
-    name=$(basename "$dir")
-    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
-    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
-      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-      ((fail++)) || true
-      continue
-    fi
-    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
-    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-      ((fail++)) || true
-      continue
-    fi
-    after=$(git -C "$dir" rev-parse HEAD)
-    if [[ "$before" == "$after" ]]; then
-      echo -e "\033[0;32m  ✓\033[0m $name ($default, up to date)"
-      ((unchanged++)) || true
-    else
-      echo -e "\033[0;32m  ✓\033[0m $name ($default)"
-      git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
-      ((ok++)) || true
-    fi
-  done
-  echo ""
-  echo "Pulled: $ok updated, $unchanged unchanged, $fail need attention"
-}
-
-# Force-delete every local branch except the default, then pull
-clean-all() {
-  local ok=0 fail=0 unchanged=0
-  for dir in ~/repos/*/; do
-    [[ -d "$dir/.git" ]] || continue
-    local name default branch before after removed=0
-    name=$(basename "$dir")
-    default=$(git -C "$dir" symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|^origin/||')
-    if [[ -z "$default" ]] || ! git -C "$dir" checkout --quiet "$default" 2>/dev/null; then
-      echo -e "\033[1;33m  ⚠ $name (check manually)\033[0m"
-      ((fail++)) || true
-      continue
-    fi
-    while IFS= read -r branch; do
-      [[ -z "$branch" || "$branch" == "$default" ]] && continue
-      git -C "$dir" branch -D "$branch" >/dev/null 2>&1 && ((removed++)) || true
-    done < <(git -C "$dir" branch --format='%(refname:short)')
-    before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
-    if ! git -C "$dir" pull --rebase --quiet 2>/dev/null; then
-      echo -e "\033[1;33m  ⚠ $name ($default, removed $removed, pull failed)\033[0m"
-      ((fail++)) || true
-      continue
-    fi
-    after=$(git -C "$dir" rev-parse HEAD)
-    if [[ "$before" == "$after" ]]; then
-      echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed, up to date)"
-      ((unchanged++)) || true
-    else
-      echo -e "\033[0;32m  ✓\033[0m $name ($default, removed $removed)"
-      git -C "$dir" --no-pager diff --stat "$before..$after" | sed 's/^/      /'
-      ((ok++)) || true
-    fi
-  done
-  echo ""
-  echo "Cleaned: $ok updated, $unchanged unchanged, $fail need attention"
-}
+# pull-all and clean-all live in scripts/ and are symlinked into
+# ~/.local/bin by bootstrap/install-scripts.sh.
 
 # <<< setup-xubuntu-workstation <<<
 BASHRC_BLOCK


### PR DESCRIPTION
## Summary
- Promote `pull-all` and `clean-all` from inline `.bashrc` functions (duplicated across all four bootstrap scripts inside heredocs) to standalone executables in [scripts/](scripts/), distributed by [bootstrap/install-scripts.sh](bootstrap/install-scripts.sh) — the same path `gh-issue` already uses.
- Single source of truth, real shellcheck on real files, edits ship via `git pull` instead of a full bootstrap re-run.
- Also wires `install-scripts.sh` into [setup-ubuntu-laptop.sh](setup-ubuntu-laptop.sh), which was missed when the deployment was added to the other three bootstraps.
- Net diff: +114 / −277. The functions stay byte-equivalent in behavior (default-branch checkout → pull → diffstat → updated/unchanged/fail summary).

## Test plan
- [x] `shellcheck --severity=warning` clean on `scripts/pull-all`, `scripts/clean-all`, and all four `setup-*.sh` files.
- [x] `bash bootstrap/install-scripts.sh` symlinks both new files into `~/.local/bin/` (verified on the host running this branch).
- [x] `pull-all` invoked via the symlink ran end-to-end against `~/repos/`, produced the expected `up to date` output and summary.
- [ ] After merge, run a fresh bootstrap on at least one target (Fedora or Ubuntu laptop) to confirm step 16 wires the symlinks and the post-install help line still works.
- [ ] On an already-bootstrapped workstation, re-source `.bashrc` after pulling main: confirm `pull-all` resolves to the symlink in `~/.local/bin/` rather than the (now-removed) function. Old shell sessions that still have the function defined will keep using it until reopened — expected, no fix needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)