### PR TITLE
fix: resolve install-scripts.sh path when setup script runs from outside repo

### DIFF
--- a/bootstrap/install-scripts.sh
+++ b/bootstrap/install-scripts.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
-    echo "error: not inside a git repository" >&2
-    exit 1
-}
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+REPO_ROOT=$(dirname "$SCRIPT_DIR")
 
 SCRIPTS_DIR="$REPO_ROOT/scripts"
 BIN_DIR="$HOME/.local/bin"

--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -1152,10 +1152,14 @@ STARSHIP_CONF
 success "Starship config written."
 
 # --- 15. Install scripts into ~/.local/bin ----------------------------------
-SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 section "15/$TOTAL_STEPS — Installing Scripts into ~/.local/bin"
-bash "$SCRIPT_DIR/bootstrap/install-scripts.sh"
-success "Scripts installed."
+WB_REPO="$REPOS_DIR/workstation-bootstrap"
+if [[ -d "$WB_REPO" ]]; then
+  bash "$WB_REPO/bootstrap/install-scripts.sh"
+  success "Scripts installed."
+else
+  warn "workstation-bootstrap not found at $WB_REPO — skipping script installation"
+fi
 
 # ============================================================================
 section "🎉 Setup Complete!"

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -1299,10 +1299,14 @@ info "Session type: KDE Plasma X11 (Wayland is not supported over XRDP)"
 info "Recommended: set RDP client resolution to 1920x1080 (4K causes rendering issues with software GL)"
 
 # --- 16. Install scripts into ~/.local/bin ----------------------------------
-SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 section "16/$TOTAL_STEPS — Installing Scripts into ~/.local/bin"
-bash "$SCRIPT_DIR/bootstrap/install-scripts.sh"
-success "Scripts installed."
+WB_REPO="$REPOS_DIR/workstation-bootstrap"
+if [[ -d "$WB_REPO" ]]; then
+  bash "$WB_REPO/bootstrap/install-scripts.sh"
+  success "Scripts installed."
+else
+  warn "workstation-bootstrap not found at $WB_REPO — skipping script installation"
+fi
 
 # ============================================================================
 section "🎉 Setup Complete!"

--- a/setup-ubuntu-laptop.sh
+++ b/setup-ubuntu-laptop.sh
@@ -1197,10 +1197,14 @@ sudo systemctl enable --now fwupd-refresh.timer 2>/dev/null || true
 success "fwupd ready — run 'fwupdmgr refresh && fwupdmgr update' to apply firmware."
 
 # --- 16. Install scripts into ~/.local/bin ----------------------------------
-SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 section "16/$TOTAL_STEPS — Installing Scripts into ~/.local/bin"
-bash "$SCRIPT_DIR/bootstrap/install-scripts.sh"
-success "Scripts installed."
+WB_REPO="$REPOS_DIR/workstation-bootstrap"
+if [[ -d "$WB_REPO" ]]; then
+  bash "$WB_REPO/bootstrap/install-scripts.sh"
+  success "Scripts installed."
+else
+  warn "workstation-bootstrap not found at $WB_REPO — skipping script installation"
+fi
 
 # ============================================================================
 section "🎉 Setup Complete!"

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -1168,10 +1168,14 @@ success "XRDP configured — connect via Microsoft Remote Desktop at $(hostname 
 info "Recommended: set RDP client resolution to 1920x1080 (4K causes rendering issues with software GL)"
 
 # --- 16. Install scripts into ~/.local/bin ----------------------------------
-SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 section "16/$TOTAL_STEPS — Installing Scripts into ~/.local/bin"
-bash "$SCRIPT_DIR/bootstrap/install-scripts.sh"
-success "Scripts installed."
+WB_REPO="$REPOS_DIR/workstation-bootstrap"
+if [[ -d "$WB_REPO" ]]; then
+  bash "$WB_REPO/bootstrap/install-scripts.sh"
+  success "Scripts installed."
+else
+  warn "workstation-bootstrap not found at $WB_REPO — skipping script installation"
+fi
 
 # ============================================================================
 section "🎉 Setup Complete!"


### PR DESCRIPTION
When users download setup-*.sh directly to ~ and run it from there, SCRIPT_DIR resolves to ~ and ~/bootstrap/install-scripts.sh doesn't exist.

Fix setup scripts to call install-scripts.sh from $REPOS_DIR/workstation-bootstrap (where the repo is always cloned by step 10) with a graceful skip if not present.

Fix install-scripts.sh to derive REPO_ROOT from its own path instead of git rev-parse --show-toplevel, which fails when cwd is outside a git repo.

Closes #51

Generated with [Claude Code](https://claude.ai/code)