### PR TITLE
docs: update prompt example path to current repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ All three scripts install the same custom [Starship](https://starship.rs) prompt
 
 ```
  main [!] 💠 default ☁️  aws-lab (us-east-1) took 9s
-ubuntu 24.04 xubuntu:~/repos/aws-lab-infra/environments/dev ❯
+ubuntu 24.04 xubuntu:~/repos/foundry-platform-demo/environments/dev ❯
 ```
 
 - **Line 1 (context):** Git branch + dirty status, Terraform workspace, AWS profile + region, k8s context, Docker context, command duration — only appears when relevant


### PR DESCRIPTION
## Summary

The Starship prompt example in the README shows a working-directory path of `~/repos/aws-lab-infra/environments/dev`, but that repo was renamed to `foundry-platform-demo`. Updates the illustrative path to match the current repo name.

Scope: README only. The `aws-lab` AWS profile name on the same line is user-configurable on the workstation itself and not changed here.

## Test plan

- [x] Confirmed `foundry-platform-demo` is the current name of the AWS infra repo
- [ ] Rendered README example reflects the updated path

🤖 Generated with [Claude Code](https://claude.com/claude-code)