### PR TITLE
starship: collapse prompt to single line when no context is active

### DIFF
--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -1031,13 +1031,15 @@ cat > "$HOME/.config/starship.toml" << 'STARSHIP_CONF'
 # ============================================================================
 
 scan_timeout = 100
+add_newline = false
 
 # The format string controls what shows up and in what order.
-# Context modules render on line 1 (only when active), then $line_break,
-# then hostname:path + cursor on line 2. When no context is active, starship
-# collapses the empty first line automatically.
+# Context modules render on line 1 (only when active), then a newline,
+# then hostname:path + cursor on line 2. The parens around the context
+# modules collapse the entire group (and its trailing newline) when no
+# variable inside it has a value, so an idle prompt is a single line.
 format = """
-$git_branch\
+($git_branch\
 $git_status\
 $python\
 $nodejs\
@@ -1045,9 +1047,8 @@ $golang\
 $terraform\
 $aws\
 $kubernetes\
-$cmd_duration\
-$line_break\
-${custom.os}$hostname$directory\
+$cmd_duration
+)${custom.os}$hostname$directory\
 $character"""
 
 # --- Prompt character -------------------------------------------------------

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -1047,9 +1047,10 @@ cat > "$HOME/.config/starship.toml" << 'STARSHIP_CONF'
 # ============================================================================
 
 scan_timeout = 100
+add_newline = false
 
 format = """
-$git_branch\
+($git_branch\
 $git_status\
 $python\
 $nodejs\
@@ -1058,9 +1059,8 @@ $terraform\
 $aws\
 $kubernetes\
 $docker_context\
-$cmd_duration\
-$line_break\
-${custom.os}$hostname$directory\
+$cmd_duration
+)${custom.os}$hostname$directory\
 $character"""
 
 [character]

--- a/setup-ubuntu-laptop.sh
+++ b/setup-ubuntu-laptop.sh
@@ -1034,9 +1034,10 @@ cat > "$HOME/.config/starship.toml" << 'STARSHIP_CONF'
 # ============================================================================
 
 scan_timeout = 100
+add_newline = false
 
 format = """
-$git_branch\
+($git_branch\
 $git_status\
 $python\
 $nodejs\
@@ -1045,9 +1046,8 @@ $terraform\
 $aws\
 $kubernetes\
 $docker_context\
-$cmd_duration\
-$line_break\
-${custom.os}$hostname$directory\
+$cmd_duration
+)${custom.os}$hostname$directory\
 $character"""
 
 [character]

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -1013,9 +1013,10 @@ cat > "$HOME/.config/starship.toml" << 'STARSHIP_CONF'
 # ============================================================================
 
 scan_timeout = 100
+add_newline = false
 
 format = """
-$git_branch\
+($git_branch\
 $git_status\
 $python\
 $nodejs\
@@ -1024,9 +1025,8 @@ $terraform\
 $aws\
 $kubernetes\
 $docker_context\
-$cmd_duration\
-$line_break\
-${custom.os}$hostname$directory\
+$cmd_duration
+)${custom.os}$hostname$directory\
 $character"""
 
 [character]


### PR DESCRIPTION
## Summary

- Adds `add_newline = false` so Starship doesn't insert a blank line before every prompt.
- Wraps the context modules (`$git_branch`, `$python`, `$aws`, `$kubernetes`, `$docker_context`, `$cmd_duration`, …) in an optional `(...)` group. When every variable inside is empty, the entire group — including its trailing newline — collapses, leaving a single-line prompt.
- Applied uniformly to all four bootstrap scripts. Crostini's accompanying explanatory comment was also updated to match the new behavior.

## Before / after

**Idle shell, before:**
```
$ ls
file1  file2
                       ← blank line from add_newline
                       ← blank line from $line_break with no context
ubuntu 26.04 cpitzi-ThinkPad:~ ❯
```

**Idle shell, after:**
```
$ ls
file1  file2
ubuntu 26.04 cpitzi-ThinkPad:~ ❯
```

**Contextful shell (e.g., inside a git repo), after:** unchanged — context modules still render on line 1, prompt on line 2.

## Test plan

- [x] `shellcheck --severity=warning setup-*.sh` clean
- [x] Live-tested on `cpitzi-ThinkPad` (Ubuntu) — idle prompt collapses to one line, git-repo prompt still shows branch + path
- [ ] Re-running bootstrap script overwrites `~/.config/starship.toml` cleanly (idempotent regen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)