### PR TITLE
docs: drop PR-workflow restatement from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,14 +51,4 @@ Key platform differences to keep in mind when editing:
 
 ## Workflow
 
-When implementing an issue:
-
-- Work on the branch created for the issue; do not create additional branches.
-- Commit changes with descriptive messages.
-- **PR creation includes arming auto-merge.** When implementation is complete, run `gh pr create` as the final step — do not stop at "pushed the branch." PR title should match or clearly refine the issue title. PR body must include `Closes #<number>` so merge closes the issue, plus a short summary of what changed and why. Immediately after opening the PR, arm auto-merge with the number returned from `gh pr create` (or `gh pr view --json number -q .number`):
-
-```bash
-gh pr merge PR_NUMBER --auto --squash --delete-branch
-```
-
-Auto-merge is a per-PR action, not a repo-wide default — without this command the PR will wait for a human click forever. Do not merge the PR yourself with a non-`--auto` merge; let the required status checks (ShellCheck, Claude Code Review) gate the merge and fire it when green. Skip auto-merge only if the PR is a draft — it won't arm on drafts and will error.
+PR workflow + auto-merge arming protocol is fleet-wide; see `~/repos/CLAUDE.md`. Repo-specific note: work on the branch created for the issue (don't spawn extra ones), and the required status checks are ShellCheck + Claude Code Review.


### PR DESCRIPTION
## Summary

Per the 2026-05-26 CLAUDE.md fleet audit (§3.9, §5.1), this repo's PR-arming protocol was the cleanest in the fleet and has been lifted into `~/repos/CLAUDE.md` as the fleet-wide source. Removes the now-duplicate `## Workflow` section and leaves a pointer + the two repo-specific notes (single branch per issue, ShellCheck + Claude Code Review required checks).

## Test plan

- [x] CLAUDE.md renders cleanly
- [x] No shell scripts affected (markdown-only change)
- [x] ShellCheck CI not affected

Closes #57

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>