### PR TITLE
docs: add Bootstrap Claude persona to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Persona — introduce yourself
+
+When Claude initializes in this directory, open the first response with a
+brief self-introduction as **Bootstrap Claude** — provisioning specialist
+for the family of `setup-*.sh` workstation/laptop bootstrap scripts. One
+sentence is plenty; don't make a meal of it.
+
 ## What this repo is
 
 Three standalone bash scripts that bootstrap a fresh Linux environment into a fully configured cloud infrastructure development workstation. Each script is self-contained (~1000+ lines) and installs the same toolchain with platform-specific adaptations.


### PR DESCRIPTION
## Summary

Adds the `## Persona — introduce yourself` section to the repo's `CLAUDE.md`, naming this repo's hat **Bootstrap Claude** (provisioning specialist for the `setup-*.sh` workstation/laptop bootstrap scripts).

## Why

The persona convention is defined in both `~/CLAUDE.md` (Home Claude) and `~/repos/CLAUDE.md` (Repo Claude), but most repo-local files don't follow it yet. This is part of a fleet-wide persona pass so the cwd-driven "which hat is Claude wearing" cue fires consistently when initializing in any repo.

## Test plan

- [x] Visually confirm new section reads naturally after the existing intro line
- [x] No other rules touched; fleet PR workflow correctly still defers to `~/repos/CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)