### PR TITLE
Add claude-cost-export: local-session cost → Fleet dashboard

### DIFF
--- a/claude-cost-export/README.md
+++ b/claude-cost-export/README.md
@@ -1,0 +1,87 @@
+# claude-cost-export
+
+Ship the cost of **local, interactive** Claude Code sessions to the homelab
+Grafana **"Claude Runner Fleet"** dashboard, so a workstation shows up next to
+the [bullpen](https://github.com/PitziLabs/bullpen) agents under a **Local
+sessions** row (`source="local"`, `worker=<hostname>`).
+
+The bullpen gets `total_cost_usd` for free from headless `claude -p --output-format
+json`. Interactive sessions have no such result blob, so this tool reconstructs
+per-session cost from the transcript and ships one event per finished session.
+
+## How it works
+
+```
+~/.claude/projects/**/*.jsonl   (transcripts — the source of truth, written by CC)
+        │  sweep: dedupe by uuid + requestId(max output), sum tokens per model
+        ▼
+  compute cost  ×  pricing.json
+        │  one `session_complete` event per FINISHED session
+        ▼
+  spool.ndjson  ──ship──▶  Alloy Loki receiver :3100 (LXC 105) ──▶ Grafana Cloud
+        ▲                    (off-LAN POST fails → stays queued → drains later)
+        │
+  SessionEnd hook drops done/<id>  +  systemd --user timer (every 5 min)
+```
+
+**Capture and shipping are decoupled on purpose.** The transcript on disk is the
+source of truth, so a hard kill that skips the `SessionEnd` hook is still caught
+by the timer's idle-detection backstop. The local `spool.ndjson` is what makes
+**off-LAN buffering** work: when the Loki receiver is unreachable the POST fails,
+the event stays queued, and the next on-LAN tick drains the backlog.
+
+A session is considered **finished** when its `SessionEnd` marker exists *or* its
+last transcript activity is older than `COST_IDLE_MIN` (default 30 min). Each
+session is emitted **exactly once** (guarded by `emitted.json`), and runs are
+serialized with `flock` so a timer tick can't race a manual run.
+
+## Files
+
+| File | Role |
+|---|---|
+| `cost-export.mjs` | sweep transcripts → spool, and drain spool → Loki. Phases: `sweep`, `ship`, `seed`, `all` (default). |
+| `pricing.json` | per-MTok USD price table + cache multipliers. **Drifts — keep current** (source: platform.claude.com/docs/en/about-claude/pricing). |
+| `cost-hook.sh` | `SessionEnd` hook: drops a `done/<session_id>` marker so finished sessions ship promptly. |
+| `claude-cost-export.{service,timer}` | systemd `--user` units; the timer runs `sweep + ship` every 5 min (backstop + off-LAN drainer). |
+| `install.sh` | idempotent install: copy assets → render units → merge hook → **seed** → start timer. |
+
+## Install
+
+```bash
+./install.sh        # standalone; also called by workstation-bootstrap setup-*.sh
+```
+
+Install **seeds** the guard (claims existing sessions without shipping) so only
+sessions completed *after* install ship — no backfill spike. To deliberately
+backfill history afterward:
+
+```bash
+COST_LOOKBACK_DAYS=90 flock -n ~/.claude/cost-export/.lock \
+  node ~/.claude/cost-export/cost-export.mjs sweep
+```
+
+## Cost basis
+
+Cost is **computed** (CC doesn't write dollars to the transcript) as
+`tokens × pricing.json`, with cache reads at 0.1×, 5-min cache writes at 1.25×,
+1-hour cache writes at 2× base input, and Opus fast-mode at 2× rates. This is the
+same API-list-price basis the fleet reports — an estimate, not a billed amount
+(local sessions run on a subscription). Raw token counts are shipped alongside
+`cost_usd`, so totals are recomputable if prices change.
+
+## Config (env)
+
+`COST_STATE_DIR` · `COST_PROJECTS_DIR` · `COST_PRICING` · `COST_LOKI_URL`
+(default `http://192.168.139.20:3100/loki/api/v1/push`) · `COST_IDLE_MIN` (30) ·
+`COST_LOOKBACK_DAYS` (14) · `COST_WORKER` (hostname) · `COST_REJECT_OLD_H` (160).
+
+## Known limits
+
+- **Resume undercount.** A session emitted after idle, then resumed (`claude
+  --resume`), is not re-emitted; later cost is missed. Rare; favored over the
+  double-counting risk of re-emitting.
+- **Off-LAN >~1 week.** Loki rejects log lines older than its
+  `reject_old_samples_max_age`; events older than `COST_REJECT_OLD_H` are shipped
+  with the *current* timestamp (true time preserved in the payload's `finished`).
+- **Pricing drift.** `pricing.json` is a static snapshot; update it when
+  Anthropic changes prices.

--- a/claude-cost-export/claude-cost-export.service
+++ b/claude-cost-export/claude-cost-export.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Claude Code local-session cost export (sweep transcripts + ship to Loki)
+Documentation=https://github.com/PitziLabs/workstation-bootstrap/tree/main/claude-cost-export
+After=network-online.target
+
+[Service]
+Type=oneshot
+# __NODE_BIN__ and __INSTALL_DIR__ are substituted by install.sh at install time
+# (systemd --user does not inherit nvm's PATH, so node is referenced absolutely).
+# flock -n serializes against any manual run so concurrent sweeps can't race the
+# emit-once guard (-n = skip this tick rather than queue if one is already running).
+ExecStart=/usr/bin/flock -n __INSTALL_DIR__/.lock __NODE_BIN__ __INSTALL_DIR__/cost-export.mjs all
+Nice=10
+IOSchedulingClass=idle

--- a/claude-cost-export/claude-cost-export.timer
+++ b/claude-cost-export/claude-cost-export.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Periodic Claude Code local-session cost export
+Documentation=https://github.com/PitziLabs/workstation-bootstrap/tree/main/claude-cost-export
+
+[Timer]
+# Backstop + off-LAN drainer: catches sessions the SessionEnd hook missed
+# (hard kills) and retries any spool entries that failed to ship while off-LAN.
+OnBootSec=3min
+OnUnitActiveSec=5min
+# Don't all fire at once if several machines share a clock
+RandomizedDelaySec=30
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/claude-cost-export/cost-export.mjs
+++ b/claude-cost-export/cost-export.mjs
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+/* eslint-disable */
+/**
+ * cost-export.mjs — capture finished Claude Code interactive sessions and ship
+ * them to the homelab Loki receiver so local cost lands on the "Claude Runner
+ * Fleet" Grafana dashboard alongside the bullpen agents.
+ *
+ * Two phases, run in sequence (default) or individually:
+ *   sweep  — scan ~/.claude/projects/**.jsonl, compute per-session tokens + cost
+ *            for FINISHED sessions, append one `session_complete` event per
+ *            session to the local spool. Idempotent (emit-once, guarded by
+ *            emitted.json). Pure/local — works off-LAN.
+ *   ship   — drain unsent spool events to Loki :3100. Off-LAN POSTs fail and the
+ *            event stays queued; the next on-LAN run drains the backlog.
+ *
+ * Why a spool instead of POSTing inline: the transcript on disk is the source of
+ * truth (survives hard kills that skip the SessionEnd hook), and decoupling
+ * capture from shipping is what makes off-LAN buffering work.
+ *
+ * Token accounting mirrors the empirically-derived rules from the session-report
+ * skill: dedupe entries globally by `uuid` (resumed sessions replay history),
+ * and dedupe API calls by `requestId` keeping the max `output_tokens` (one
+ * response is split across several assistant entries; only the last carries the
+ * final output count).
+ *
+ * Cost is COMPUTED from token counts × pricing.json (Claude Code does not write
+ * dollars to the transcript). Prices drift — keep pricing.json current.
+ *
+ * Env (all optional):
+ *   COST_STATE_DIR     state/spool dir         (default ~/.claude/cost-export)
+ *   COST_PROJECTS_DIR  transcripts root        (default ~/.claude/projects)
+ *   COST_PRICING       pricing.json path       (default <scriptdir>/pricing.json)
+ *   COST_LOKI_URL      Loki push endpoint       (default http://192.168.139.20:3100/loki/api/v1/push)
+ *   COST_IDLE_MIN      mins idle ⇒ "finished"   (default 30)
+ *   COST_LOOKBACK_DAYS only emit sessions active within N days (default 14)
+ *   COST_WORKER        worker label             (default hostname)
+ *   COST_REJECT_OLD_H  re-stamp Loki ts to now if event older than N h (default 160)
+ *
+ * Usage: cost-export.mjs [sweep|ship|seed|all]   (no arg = all = sweep + ship)
+ *   seed — mark all currently-finished sessions as already-emitted WITHOUT
+ *          shipping. Run once at install so only sessions completed AFTER
+ *          install ship; avoids a backfill spike. (Deliberate history backfill:
+ *          run `sweep` with a larger COST_LOOKBACK_DAYS instead.)
+ *
+ * Concurrency: invoke under `flock -n <state>/.lock` (the systemd unit and
+ * install.sh do). Runs are serialized so the emit-once guard can't be raced by
+ * an overlapping sweep (an early install bug shipped each backfill session 3x).
+ */
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import readline from 'readline'
+import { execFileSync } from 'child_process'
+
+const HOME = os.homedir()
+const STATE_DIR = process.env.COST_STATE_DIR || path.join(HOME, '.claude', 'cost-export')
+const PROJECTS_DIR = process.env.COST_PROJECTS_DIR || path.join(HOME, '.claude', 'projects')
+const SCRIPT_DIR = path.dirname(new URL(import.meta.url).pathname)
+const PRICING_PATH = process.env.COST_PRICING || path.join(SCRIPT_DIR, 'pricing.json')
+const LOKI_URL = process.env.COST_LOKI_URL || 'http://192.168.139.20:3100/loki/api/v1/push'
+const IDLE_MS = (parseInt(process.env.COST_IDLE_MIN || '30', 10)) * 60 * 1000
+const LOOKBACK_MS = (parseInt(process.env.COST_LOOKBACK_DAYS || '14', 10)) * 86400 * 1000
+const WORKER = process.env.COST_WORKER || os.hostname()
+const REJECT_OLD_MS = (parseInt(process.env.COST_REJECT_OLD_H || '160', 10)) * 3600 * 1000
+
+const SPOOL = path.join(STATE_DIR, 'spool.ndjson')
+const SHIPPED = path.join(STATE_DIR, 'shipped.ndjson')
+const EMITTED = path.join(STATE_DIR, 'emitted.json')
+const DONE_DIR = path.join(STATE_DIR, 'done')
+
+const NOW = Date.now()
+const phase = (process.argv[2] || 'all').toLowerCase()
+
+function log(...a) { console.error('[cost-export]', ...a) }
+function ensureDirs() { for (const d of [STATE_DIR, DONE_DIR]) fs.mkdirSync(d, { recursive: true }) }
+function readJson(p, dflt) { try { return JSON.parse(fs.readFileSync(p, 'utf8')) } catch { return dflt } }
+
+// ---------------------------------------------------------------------------
+// Pricing
+// ---------------------------------------------------------------------------
+const PRICING = readJson(PRICING_PATH, null)
+if (!PRICING) { log('FATAL: cannot read pricing at', PRICING_PATH); process.exit(2) }
+const MULT = PRICING.multipliers
+
+// Normalize a transcript model string to a pricing table key.
+// Strips date suffixes ("-20251001") and tier markers ("[1m]"); matches by
+// longest-prefix so future point releases still resolve. Unknown → _default.
+function priceKeyFor(model) {
+  if (!model) return PRICING._default
+  let m = String(model).toLowerCase().replace(/\[[^\]]*\]/g, '').trim()
+  if (PRICING.models[m]) return m
+  m = m.replace(/-\d{6,}$/, '') // drop trailing date
+  if (PRICING.models[m]) return m
+  let best = null
+  for (const k of Object.keys(PRICING.models)) {
+    if (m.startsWith(k) && (!best || k.length > best.length)) best = k
+  }
+  return best || PRICING._default
+}
+
+// Cost (USD) for one token bucket given a price key and speed ("fast"/other).
+function costFor(key, speed, t) {
+  const base = PRICING.models[key] || PRICING.models[PRICING._default]
+  const rate = (speed === 'fast' && base.fast) ? base.fast : base
+  const inP = rate.input / 1e6, outP = rate.output / 1e6
+  return (
+    t.inUncached * inP +
+    t.cacheRead * inP * MULT.cache_read +
+    t.cacheWrite5m * inP * MULT.cache_write_5m +
+    t.cacheWrite1h * inP * MULT.cache_write_1h +
+    t.output * outP
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Transcript discovery + classification (mirrors session-report)
+// ---------------------------------------------------------------------------
+function* walk(dir) {
+  let ents
+  try { ents = fs.readdirSync(dir, { withFileTypes: true }) } catch { return }
+  for (const e of ents) {
+    const p = path.join(dir, e.name)
+    if (e.isDirectory()) yield* walk(p)
+    else if (e.isFile() && e.name.endsWith('.jsonl')) yield p
+  }
+}
+
+// Returns { project (dir-encoded), sessionId } for a transcript path.
+// main:     <projectDir>/<sessionId>.jsonl
+// subagent: <projectDir>/<sessionId>/.../*.jsonl  → rolls into parent session
+function classify(p) {
+  const rel = path.relative(PROJECTS_DIR, p)
+  const parts = rel.split(path.sep)
+  const projectDir = parts[0]
+  if (parts.length === 2) return { projectDir, sessionId: path.basename(parts[1], '.jsonl') }
+  return { projectDir, sessionId: parts[1] } // deeper ⇒ session dir is parts[1]
+}
+
+function emptyTokens() {
+  return { inUncached: 0, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0, output: 0 }
+}
+
+function newSession(projectDir) {
+  return {
+    projectDir,
+    cwd: null,
+    firstTs: null,
+    lastTs: null,
+    humanTurns: 0,
+    apiCalls: 0,
+    // pricing bucket key `${priceKey}|${speed}` → tokens
+    buckets: new Map(),
+    // dedupe of API calls by requestId → { output, bucketKey, usage } (keep max output)
+    byRequest: new Map(),
+  }
+}
+
+const sessions = new Map()           // sessionId → session
+const seenUuids = new Set()          // global replay dedupe
+
+function isHumanPrompt(e) {
+  if (e.type !== 'user') return false
+  if (e.isSidechain || e.isMeta || e.isCompactSummary) return false
+  const c = e.message && e.message.content
+  if (typeof c === 'string') return c.trim().length > 0
+  if (Array.isArray(c)) return c.some(b => b && b.type === 'text') // not a tool_result-only turn
+  return false
+}
+
+function ingestFile(p) {
+  return new Promise((resolve) => {
+    const { projectDir, sessionId } = classify(p)
+    if (!sessions.has(sessionId)) sessions.set(sessionId, newSession(projectDir))
+    const s = sessions.get(sessionId)
+    const rl = readline.createInterface({ input: fs.createReadStream(p, { encoding: 'utf8' }), crlfDelay: Infinity })
+    rl.on('line', (line) => {
+      if (!line) return
+      let e
+      try { e = JSON.parse(line) } catch { return }
+      if (e.uuid) { if (seenUuids.has(e.uuid)) return; seenUuids.add(e.uuid) }
+
+      if (e.cwd && !s.cwd) s.cwd = e.cwd
+      const ts = e.timestamp ? Date.parse(e.timestamp) : NaN
+      if (!isNaN(ts)) {
+        if (s.firstTs === null || ts < s.firstTs) s.firstTs = ts
+        if (s.lastTs === null || ts > s.lastTs) s.lastTs = ts
+      }
+      if (isHumanPrompt(e)) s.humanTurns++
+
+      if (e.type !== 'assistant') return
+      const msg = e.message || {}
+      const u = msg.usage
+      if (!u) return
+      const key = e.requestId || msg.id || e.uuid
+      if (!key) return
+      const out = u.output_tokens || 0
+      const prev = s.byRequest.get(key)
+      if (prev && prev.output >= out) return // keep the entry with max output_tokens
+      const priceKey = priceKeyFor(msg.model)
+      const speed = (u.speed === 'fast' || e.speed === 'fast') ? 'fast' : 'standard'
+      s.byRequest.set(key, { output: out, priceKey, speed, usage: u, model: msg.model })
+    })
+    rl.on('close', resolve)
+    rl.on('error', () => resolve())
+  })
+}
+
+// Fold the deduped per-request usage into pricing buckets + apiCalls.
+function finalizeSession(s) {
+  for (const r of s.byRequest.values()) {
+    s.apiCalls++
+    const bk = `${r.priceKey}|${r.speed}`
+    let t = s.buckets.get(bk)
+    if (!t) { t = emptyTokens(); s.buckets.set(bk, t) }
+    const u = r.usage
+    const cc = u.cache_creation || {}
+    const w5 = cc.ephemeral_5m_input_tokens
+    const w1 = cc.ephemeral_1h_input_tokens
+    const ccTotal = u.cache_creation_input_tokens || 0
+    if (w5 != null || w1 != null) {
+      t.cacheWrite5m += w5 || 0
+      t.cacheWrite1h += w1 || 0
+    } else {
+      t.cacheWrite5m += ccTotal // no breakdown ⇒ assume 5m TTL
+    }
+    t.inUncached += u.input_tokens || 0
+    t.cacheRead += u.cache_read_input_tokens || 0
+    t.output += u.output_tokens || 0
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sweep
+// ---------------------------------------------------------------------------
+function projectLabel(s) {
+  let base
+  if (s.cwd) base = path.basename(s.cwd)
+  else base = decodeURIComponent(s.projectDir).replace(/^-/, '').split('-').pop()
+  if (!base || base === path.basename(HOME)) base = 'home'
+  return base.toLowerCase().replace(/[^a-z0-9_.-]+/g, '-').replace(/^-+|-+$/g, '') || 'home'
+}
+
+async function sweep(seedOnly = false) {
+  ensureDirs()
+  const emitted = readJson(EMITTED, {})
+  const doneMarkers = new Set(fs.existsSync(DONE_DIR) ? fs.readdirSync(DONE_DIR) : [])
+
+  for (const f of walk(PROJECTS_DIR)) await ingestFile(f)
+
+  let emittedCount = 0
+  const spoolLines = []
+  for (const [sessionId, s] of sessions) {
+    if (emitted[sessionId]) continue                       // emit-once guard
+    if (s.lastTs === null) continue
+    if (NOW - s.lastTs > LOOKBACK_MS) continue              // too old to bother
+    const finished = doneMarkers.has(sessionId) || (NOW - s.lastTs > IDLE_MS)
+    if (!finished) continue                                 // still active — don't emit a partial
+
+    if (seedOnly) { emitted[sessionId] = { seeded: true, at: NOW }; emittedCount++; continue }
+
+    finalizeSession(s)
+    if (s.apiCalls === 0) { emitted[sessionId] = { skipped: 'no-api-calls', at: NOW }; continue }
+
+    let cost = 0
+    const tokTotals = emptyTokens()
+    let topModel = null, topOut = -1
+    for (const [bk, t] of s.buckets) {
+      const [priceKey, speed] = bk.split('|')
+      cost += costFor(priceKey, speed, t)
+      for (const k of Object.keys(tokTotals)) tokTotals[k] += t[k]
+      if (t.output > topOut) { topOut = t.output; topModel = bk.split('|')[0] }
+    }
+    cost = Math.round(cost * 1e6) / 1e6
+    const durationSec = s.firstTs && s.lastTs ? Math.round((s.lastTs - s.firstTs) / 1000) : 0
+    const project = projectLabel(s)
+    const inputTotal = tokTotals.inUncached + tokTotals.cacheRead + tokTotals.cacheWrite5m + tokTotals.cacheWrite1h
+
+    const event = {
+      event: 'session_complete',
+      session_id: sessionId,
+      source: 'local',
+      worker: WORKER,
+      project,
+      model: topModel || 'unknown',
+      status: 'completed',
+      cost_usd: cost,
+      num_turns: s.humanTurns,
+      api_calls: s.apiCalls,
+      duration_sec: durationSec,
+      input_tokens: inputTotal,
+      output_tokens: tokTotals.output,
+      cache_read_tokens: tokTotals.cacheRead,
+      cache_write_tokens: tokTotals.cacheWrite5m + tokTotals.cacheWrite1h,
+      cwd: s.cwd || '',
+      started: s.firstTs ? new Date(s.firstTs).toISOString() : '',
+      finished: s.lastTs ? new Date(s.lastTs).toISOString() : '',
+    }
+    const labels = {
+      job: 'claude_local', service: 'claude_runner', source: 'local',
+      project, model: event.model, worker: WORKER, status: 'completed',
+    }
+    spoolLines.push(JSON.stringify({ labels, finished_ms: s.lastTs, line: JSON.stringify(event) }))
+    emitted[sessionId] = { cost_usd: cost, finished: event.finished, at: NOW }
+    emittedCount++
+  }
+
+  if (spoolLines.length) fs.appendFileSync(SPOOL, spoolLines.join('\n') + '\n')
+  fs.writeFileSync(EMITTED, JSON.stringify(emitted, null, 0))
+  // clear done markers we've now consumed
+  for (const m of doneMarkers) if (emitted[m]) { try { fs.unlinkSync(path.join(DONE_DIR, m)) } catch {} }
+  log(`${seedOnly ? 'seed' : 'sweep'}: ${emittedCount} session(s) ${seedOnly ? 'claimed (not shipped)' : 'spooled'} (${sessions.size} scanned)`)
+  return emittedCount
+}
+
+// ---------------------------------------------------------------------------
+// Ship
+// ---------------------------------------------------------------------------
+function postToLoki(rec) {
+  let tsMs = rec.finished_ms || NOW
+  if (NOW - tsMs > REJECT_OLD_MS) tsMs = NOW   // avoid Loki reject-old; true time stays in the line
+  const tsNs = String(tsMs) + '000000'
+  const payload = JSON.stringify({ streams: [{ stream: rec.labels, values: [[tsNs, rec.line]] }] })
+  try {
+    execFileSync('curl', ['-sf', '-m', '10', '-XPOST', LOKI_URL,
+      '-H', 'Content-Type: application/json', '--data-binary', payload],
+      { stdio: ['ignore', 'ignore', 'ignore'] })
+    return true
+  } catch { return false }
+}
+
+function ship() {
+  if (!fs.existsSync(SPOOL)) { log('ship: spool empty'); return }
+  const lines = fs.readFileSync(SPOOL, 'utf8').split('\n').filter(Boolean)
+  if (!lines.length) { try { fs.unlinkSync(SPOOL) } catch {}; return }
+  const remaining = [], shipped = []
+  let okCount = 0, failCount = 0
+  for (const ln of lines) {
+    let rec
+    try { rec = JSON.parse(ln) } catch { continue } // drop corrupt lines
+    if (postToLoki(rec)) { shipped.push(ln); okCount++ }
+    else { remaining.push(ln); failCount++ }
+  }
+  // rewrite spool with only the unshipped; append shipped to the audit log
+  if (remaining.length) fs.writeFileSync(SPOOL, remaining.join('\n') + '\n')
+  else { try { fs.unlinkSync(SPOOL) } catch {} }
+  if (shipped.length) fs.appendFileSync(SHIPPED, shipped.join('\n') + '\n')
+  log(`ship: ${okCount} sent, ${failCount} queued (off-LAN?)`)
+}
+
+// ---------------------------------------------------------------------------
+const main = async () => {
+  if (phase === 'seed') { await sweep(true); return }
+  if (phase === 'sweep' || phase === 'all') await sweep(false)
+  if (phase === 'ship' || phase === 'all') ship()
+}
+main().catch((e) => { log('error:', e && e.stack || e); process.exit(1) })

--- a/claude-cost-export/cost-hook.sh
+++ b/claude-cost-export/cost-hook.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Claude Code SessionEnd hook: mark a session "finished" so the next sweep ships
+# it promptly instead of waiting for the idle-timeout backstop. Best-effort and
+# intentionally trivial — a hard kill that skips this hook is still caught by the
+# sweep's idle detection, because the transcript on disk is the source of truth.
+#
+# Wired via ~/.claude/settings.json hooks.SessionEnd. Reads the hook payload
+# (JSON) on stdin; we only need session_id. Never blocks, never fails the session.
+set -uo pipefail
+STATE_DIR="${COST_STATE_DIR:-$HOME/.claude/cost-export}"
+DONE_DIR="$STATE_DIR/done"
+
+payload="$(cat 2>/dev/null || true)"
+sid=""
+if command -v jq >/dev/null 2>&1; then
+  sid="$(printf '%s' "$payload" | jq -r '.session_id // empty' 2>/dev/null || true)"
+fi
+# jq-less fallback
+[ -z "$sid" ] && sid="$(printf '%s' "$payload" | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]+"' | head -1 | sed -E 's/.*"([^"]+)"$/\1/')"
+
+[ -z "$sid" ] && exit 0
+mkdir -p "$DONE_DIR" 2>/dev/null || exit 0
+: > "$DONE_DIR/$sid" 2>/dev/null || true
+exit 0

--- a/claude-cost-export/install.sh
+++ b/claude-cost-export/install.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# install.sh — set up Claude Code local-session cost export on this workstation.
+# Idempotent: safe to re-run (re-syncs assets, won't duplicate the hook).
+#
+# Installs:
+#   ~/.claude/cost-export/{cost-export.mjs,pricing.json,cost-hook.sh}  (assets + state)
+#   ~/.config/systemd/user/claude-cost-export.{service,timer}          (5-min sweep+ship)
+#   a SessionEnd hook in ~/.claude/settings.json                       (prompt finalize)
+#
+# Run standalone:  claude-cost-export/install.sh
+# Called by the workstation-bootstrap setup-*.sh scripts after repos are cloned.
+set -euo pipefail
+
+SRC_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+INSTALL_DIR="$HOME/.claude/cost-export"
+UNIT_DIR="$HOME/.config/systemd/user"
+SETTINGS="$HOME/.claude/settings.json"
+
+c_ok()   { printf '\033[0;32m[ OK ]\033[0m %s\n' "$*"; }
+c_info() { printf '\033[0;34m[INFO]\033[0m %s\n' "$*"; }
+c_warn() { printf '\033[1;33m[WARN]\033[0m %s\n' "$*"; }
+c_fail() { printf '\033[0;31m[FAIL]\033[0m %s\n' "$*"; exit 1; }
+
+# --- 1. Prerequisites ------------------------------------------------------
+NODE_BIN="$(command -v node || true)"
+[ -z "$NODE_BIN" ] && c_fail "node not found on PATH — install Node (the bootstrap installs it via nvm) before running this."
+command -v jq >/dev/null 2>&1 || c_fail "jq not found — install jq first (it's in the bootstrap's QoL tools)."
+command -v curl >/dev/null 2>&1 || c_fail "curl not found."
+c_info "node: $NODE_BIN  ($($NODE_BIN --version))"
+
+# --- 2. Copy assets --------------------------------------------------------
+mkdir -p "$INSTALL_DIR/done"
+install -m 0755 "$SRC_DIR/cost-export.mjs" "$INSTALL_DIR/cost-export.mjs"
+install -m 0755 "$SRC_DIR/cost-hook.sh"    "$INSTALL_DIR/cost-hook.sh"
+# pricing.json: install fresh on first run; on re-run keep the local copy if the
+# operator has hand-edited it (compare against the shipped one and warn on drift).
+if [ ! -f "$INSTALL_DIR/pricing.json" ]; then
+  install -m 0644 "$SRC_DIR/pricing.json" "$INSTALL_DIR/pricing.json"
+  c_ok "installed pricing.json"
+elif ! cmp -s "$SRC_DIR/pricing.json" "$INSTALL_DIR/pricing.json"; then
+  c_warn "pricing.json differs from the repo copy — leaving your local version. Diff: diff $INSTALL_DIR/pricing.json $SRC_DIR/pricing.json"
+fi
+c_ok "assets installed to $INSTALL_DIR"
+
+# --- 3. systemd --user units (substitute node + install paths) -------------
+# Render + load the units now, but DON'T start the timer yet — the guard must be
+# seeded first (step 5), or the timer's catch-up run would ship the whole backlog.
+mkdir -p "$UNIT_DIR"
+sed -e "s#__NODE_BIN__#$NODE_BIN#g" -e "s#__INSTALL_DIR__#$INSTALL_DIR#g" \
+  "$SRC_DIR/claude-cost-export.service" > "$UNIT_DIR/claude-cost-export.service"
+install -m 0644 "$SRC_DIR/claude-cost-export.timer" "$UNIT_DIR/claude-cost-export.timer"
+systemctl --user daemon-reload
+c_ok "units installed (timer not started yet)"
+
+# --- 4. SessionEnd hook in settings.json (idempotent merge) ----------------
+HOOK_CMD="$INSTALL_DIR/cost-hook.sh"
+mkdir -p "$(dirname "$SETTINGS")"
+[ -f "$SETTINGS" ] || echo '{}' > "$SETTINGS"
+jq -e . "$SETTINGS" >/dev/null 2>&1 || c_fail "$SETTINGS is not valid JSON — refusing to touch it."
+exists="$(jq -r --arg c "$HOOK_CMD" \
+  '[(.hooks.SessionEnd // [])[].hooks[]?.command] | index($c) != null' "$SETTINGS" 2>/dev/null || echo false)"
+if [ "$exists" != "true" ]; then
+  cp -p "$SETTINGS" "$SETTINGS.bak.$(date +%Y%m%d%H%M%S)"   # backup before edit
+  tmp="$(mktemp)"
+  jq --arg c "$HOOK_CMD" '
+    .hooks //= {} |
+    .hooks.SessionEnd //= [] |
+    .hooks.SessionEnd += [ { "hooks": [ { "type": "command", "command": $c } ] } ]
+  ' "$SETTINGS" > "$tmp" && mv "$tmp" "$SETTINGS"
+  c_ok "added SessionEnd hook to $SETTINGS (backup saved)"
+else
+  c_ok "SessionEnd hook already present"
+fi
+
+# --- 5. SEED the guard BEFORE starting the timer ---------------------------
+# Claim all currently-finished sessions as already-emitted so only sessions that
+# complete AFTER install ship — no backfill spike, no bulk-ship race. Must run
+# before the timer is enabled. Deliberate history backfill is an explicit opt-in
+# (see the hint below).
+if [ ! -f "$INSTALL_DIR/emitted.json" ]; then
+  c_info "seeding emit-guard (claiming existing sessions without shipping)..."
+  /usr/bin/flock -n "$INSTALL_DIR/.lock" "$NODE_BIN" "$INSTALL_DIR/cost-export.mjs" seed || c_warn "seed returned non-zero"
+else
+  c_info "emitted.json exists — skipping seed (already initialized)."
+fi
+
+# --- 6. NOW start the timer (guard is populated) ---------------------------
+systemctl --user enable --now claude-cost-export.timer
+c_ok "timer enabled: $(systemctl --user is-active claude-cost-export.timer) ($(systemctl --user is-enabled claude-cost-export.timer))"
+# Linger lets the timer run even when not logged into a session (best-effort).
+if ! loginctl show-user "$USER" 2>/dev/null | grep -q 'Linger=yes'; then
+  if loginctl enable-linger "$USER" 2>/dev/null; then
+    c_ok "enabled linger for $USER"
+  else
+    c_warn "could not enable linger (needs root). For run-while-logged-out: sudo loginctl enable-linger $USER"
+  fi
+fi
+
+cat <<EOF
+
+$(c_ok "Claude Code cost export installed.")
+  State:    $INSTALL_DIR
+  Timer:    every 5 min (systemctl --user list-timers claude-cost-export.timer)
+  Spool:    $INSTALL_DIR/spool.ndjson   (unsent; drains when on-LAN)
+  Run now:  flock -n $INSTALL_DIR/.lock $NODE_BIN $INSTALL_DIR/cost-export.mjs        # sweep + ship
+  Backfill: COST_LOOKBACK_DAYS=90 flock -n $INSTALL_DIR/.lock $NODE_BIN $INSTALL_DIR/cost-export.mjs sweep
+  Dashboard: "Claude Runner Fleet" → Local sessions row  (source="local")
+EOF

--- a/claude-cost-export/pricing.json
+++ b/claude-cost-export/pricing.json
@@ -1,0 +1,24 @@
+{
+  "_comment": "Per-MTok USD pricing for Claude Code local-session cost estimation. Source: https://platform.claude.com/docs/en/about-claude/pricing (fetched 2026-06-16). Cache rates are DERIVED from base input via the standard, uniform multipliers below — do not hand-edit per-model cache numbers. To update when Anthropic changes prices: edit the `input`/`output` for the affected models (and `fast` for Opus). Unknown models fall back to `_default`.",
+  "multipliers": {
+    "cache_write_5m": 1.25,
+    "cache_write_1h": 2.0,
+    "cache_read": 0.1
+  },
+  "_default": "claude-opus-4-8",
+  "models": {
+    "claude-opus-4-8":   { "input": 5,    "output": 25, "fast": { "input": 10, "output": 50 } },
+    "claude-opus-4-7":   { "input": 5,    "output": 25, "fast": { "input": 30, "output": 150 } },
+    "claude-opus-4-6":   { "input": 5,    "output": 25, "fast": { "input": 30, "output": 150 } },
+    "claude-opus-4-5":   { "input": 5,    "output": 25 },
+    "claude-opus-4-1":   { "input": 15,   "output": 75 },
+    "claude-opus-4-0":   { "input": 15,   "output": 75 },
+    "claude-sonnet-4-6": { "input": 3,    "output": 15 },
+    "claude-sonnet-4-5": { "input": 3,    "output": 15 },
+    "claude-sonnet-4-0": { "input": 3,    "output": 15 },
+    "claude-haiku-4-5":  { "input": 1,    "output": 5 },
+    "claude-haiku-3-5":  { "input": 0.8,  "output": 4 },
+    "claude-fable-5":    { "input": 10,   "output": 50 },
+    "claude-mythos-5":   { "input": 10,   "output": 50 }
+  }
+}

--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -1164,6 +1164,16 @@ else
   warn "workstation-bootstrap not found at $WB_REPO — skipping script installation"
 fi
 
+# --- Claude Code cost export (local-session cost → homelab Grafana) ---------
+# Idempotent installer for the systemd --user timer + SessionEnd hook that ship
+# finished interactive-session cost to the "Claude Runner Fleet" dashboard.
+# node + jq + the cloned repo are all present by now. Non-fatal on any failure.
+# (Crostini's systemd --user may be unavailable — the installer degrades safely.)
+if [[ -x "$WB_REPO/claude-cost-export/install.sh" ]]; then
+  section "Claude Code cost export"
+  "$WB_REPO/claude-cost-export/install.sh" || warn "cost-export install failed (non-fatal — re-run later)"
+fi
+
 # ============================================================================
 section "🎉 Setup Complete!"
 echo ""

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -1310,6 +1310,15 @@ else
   warn "workstation-bootstrap not found at $WB_REPO — skipping script installation"
 fi
 
+# --- Claude Code cost export (local-session cost → homelab Grafana) ---------
+# Idempotent installer for the systemd --user timer + SessionEnd hook that ship
+# finished interactive-session cost to the "Claude Runner Fleet" dashboard.
+# node + jq + the cloned repo are all present by now. Non-fatal on any failure.
+if [[ -x "$WB_REPO/claude-cost-export/install.sh" ]]; then
+  section "Claude Code cost export"
+  "$WB_REPO/claude-cost-export/install.sh" || warn "cost-export install failed (non-fatal — re-run later)"
+fi
+
 # ============================================================================
 section "🎉 Setup Complete!"
 echo ""

--- a/setup-ubuntu-laptop.sh
+++ b/setup-ubuntu-laptop.sh
@@ -1208,6 +1208,15 @@ else
   warn "workstation-bootstrap not found at $WB_REPO — skipping script installation"
 fi
 
+# --- Claude Code cost export (local-session cost → homelab Grafana) ---------
+# Idempotent installer for the systemd --user timer + SessionEnd hook that ship
+# finished interactive-session cost to the "Claude Runner Fleet" dashboard.
+# node + jq + the cloned repo are all present by now. Non-fatal on any failure.
+if [[ -x "$WB_REPO/claude-cost-export/install.sh" ]]; then
+  section "Claude Code cost export"
+  "$WB_REPO/claude-cost-export/install.sh" || warn "cost-export install failed (non-fatal — re-run later)"
+fi
+
 # ============================================================================
 section "🎉 Setup Complete!"
 echo ""

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -1179,6 +1179,15 @@ else
   warn "workstation-bootstrap not found at $WB_REPO — skipping script installation"
 fi
 
+# --- Claude Code cost export (local-session cost → homelab Grafana) ---------
+# Idempotent installer for the systemd --user timer + SessionEnd hook that ship
+# finished interactive-session cost to the "Claude Runner Fleet" dashboard.
+# node + jq + the cloned repo are all present by now. Non-fatal on any failure.
+if [[ -x "$WB_REPO/claude-cost-export/install.sh" ]]; then
+  section "Claude Code cost export"
+  "$WB_REPO/claude-cost-export/install.sh" || warn "cost-export install failed (non-fatal — re-run later)"
+fi
+
 # ============================================================================
 section "🎉 Setup Complete!"
 echo ""


### PR DESCRIPTION
## Origin

Chris asked whether the cost metrics the bullpen emits could also be emitted from Claude Code directly, so his local interactive sessions land on the same "Claude Runner Fleet" Grafana dashboard. We compared native OpenTelemetry vs a hook-based approach; he preferred the hook path and specifically asked how reliably a `SessionEnd` hook fires and whether sessions could be buffered locally while off-LAN. This implements the design that answers both, and folds it into the bootstrap scripts as a standing workstation standard.

## What this does

Reconstructs the cost of **local, interactive** Claude Code sessions from the on-disk transcript and ships one `session_complete` event per finished session to the homelab Alloy Loki receiver (`:3100` on LXC 105) → Grafana Cloud. A workstation then appears on the Fleet dashboard under a new **Local sessions** row (`job=claude_local`, `source=local`, `worker=<hostname>`) without touching the fleet's own panels.

The bullpen gets `total_cost_usd` for free from headless `claude -p --output-format json`; interactive sessions have no such result blob, so cost is **computed** from token counts × `pricing.json` (cache reads 0.1×, 5m writes 1.25×, 1h writes 2×, Opus fast-mode 2×) — the same API-list-price basis the fleet reports.

## Design (answers the two questions)

- **`SessionEnd` is best-effort.** It fires on graceful exit but a hard kill (window close, SSH drop, crash) skips it. So the **transcript is the source of truth**; the hook just drops a `done/<id>` marker for promptness, and a systemd `--user` timer sweeps every 5 min as the backstop (a session idle > `COST_IDLE_MIN` is treated as finished). Nothing is lost to a missed hook.
- **Off-LAN buffering** falls out of decoupling capture from shipping: finished sessions go to a local `spool.ndjson`; the shipper drains it to Loki when reachable; off-LAN POSTs fail and stay queued until the next on-LAN tick.
- **Exactly-once + no races:** `emitted.json` guard + `flock` serialization. Install **seeds** the guard (claims existing sessions without shipping) so only post-install sessions ship — no backfill spike.

Token accounting reuses the empirically-derived dedup rules from the `session-report` skill (global `uuid` dedup for resumed sessions; per-`requestId` dedup keeping max `output_tokens`).

## Files

`claude-cost-export/` — `cost-export.mjs` (sweep+ship), `pricing.json`, `cost-hook.sh` (SessionEnd), `claude-cost-export.{service,timer}`, idempotent `install.sh`, `README.md`. All four `setup-*.sh` call the installer after node+jq+repos are present (non-fatal).

## Verified

- Cost math checked against hand-computation (synthetic Opus session = \$0.07 exact).
- `requestId` dedup keeps max output (810→800); idempotent re-run spools 0; `flock` serializes concurrent runs.
- Round-trip confirmed: event accepted by Loki (HTTP 204) and queried back via Grafana Cloud.
- shellcheck clean (setup scripts + bundle); `node --check` passes.

## Companion PR

Dashboard row to display this data: PitziLabs/homelab-observability (Local sessions row on `claude-runner-fleet.json`).

## Note

Pricing.json is a static snapshot of platform.claude.com pricing — update when Anthropic changes prices (raw tokens are shipped alongside `cost_usd` so totals stay recomputable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)