### PR TITLE
Add dotfiles/ for capturing hand-tuned local configs

### DIFF
--- a/dotfiles/README.md
+++ b/dotfiles/README.md
@@ -1,0 +1,74 @@
+# dotfiles — captured local configs
+
+Version-controlled copies of hand-tuned local config files, so they survive a
+machine rebuild and so a local tweak becomes a reviewable diff instead of a
+one-off edit that's lost on the next reinstall.
+
+This complements — it doesn't replace — the configs the `setup-*.sh` scripts
+generate inline (e.g. `~/.config/starship.toml`). Those are *generated* and
+belong in the scripts. This directory is for configs that are too large or too
+hand-iterated to live as a heredoc (the alacritty config is the seed: ~7.5KB
+across three theme variants).
+
+## Layout
+
+Everything under `home/` mirrors its path relative to `$HOME`:
+
+```
+dotfiles/home/.config/alacritty/alacritty.toml   ->   ~/.config/alacritty/alacritty.toml
+```
+
+The set of files under `home/` *is* the set of tracked configs. There's no
+manifest to keep in sync — the directory tree is the manifest.
+
+## Workflow
+
+Two idempotent helpers, inverses of each other:
+
+| Script | Direction | When |
+|---|---|---|
+| `install.sh` | repo → `$HOME` | After a fresh provision, or to make the repo's configs live |
+| `capture.sh` | `$HOME` → repo | After tweaking a config locally, to snapshot it back into git |
+
+```bash
+# Deploy tracked configs onto a freshly set-up machine.
+# Backs up any differing existing file to ~/.dotfiles-backup/ first.
+dotfiles/install.sh
+
+# Pull your latest local edits back into the repo, then PR them.
+dotfiles/capture.sh
+git -C ~/repos/workstation-bootstrap diff
+```
+
+Both skip files that are already identical, so re-running is safe and quiet.
+
+## Adding a new config to track
+
+Copy it under `home/`, mirroring its `$HOME`-relative path, then commit:
+
+```bash
+mkdir -p dotfiles/home/.config/foo
+cp ~/.config/foo/bar.conf dotfiles/home/.config/foo/bar.conf
+```
+
+From then on `capture.sh` keeps it fresh and `install.sh` deploys it.
+
+## Why copy, not symlink
+
+`install.sh` copies rather than symlinking so live files stay real files.
+That preserves in-place swapping — e.g. alacritty's
+`cp alacritty-aurora.toml alacritty.toml` to change the active theme would
+clobber a symlink. The cost is that local edits don't flow back automatically;
+that's what `capture.sh` is for.
+
+## Not yet wired into `setup-*.sh`
+
+The provisioning scripts don't call `install.sh` yet — for now it's a manual
+post-provision step. Wiring it in (across all four scripts, per the repo's
+keep-in-sync rule) is a sensible follow-up.
+
+## What's tracked today
+
+- **`.config/alacritty/`** — `alacritty.toml` (active) plus the `ember` and
+  `aurora` theme variants. All three pin `working_directory` so new windows
+  open in `$HOME` instead of inheriting the spawning window's cwd.

--- a/dotfiles/capture.sh
+++ b/dotfiles/capture.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# capture.sh — refresh tracked dotfiles in this repo from the live $HOME.
+#
+# The inverse of install.sh. For every file already tracked under
+# dotfiles/home/, copy the live version from $HOME back into the repo, so a
+# local tweak (e.g. an alacritty edit) becomes a reviewable git diff.
+#
+# It only refreshes files the repo ALREADY tracks — it does not slurp your
+# whole home directory. To start tracking a NEW config, copy it under
+# dotfiles/home/ once (mirroring its $HOME-relative path), then capture.sh
+# keeps it in sync from then on:
+#   mkdir -p dotfiles/home/.config/foo && cp ~/.config/foo/bar.conf "$_"/
+#
+# Usage:
+#   dotfiles/capture.sh      # then: git diff, commit, open a PR
+#
+set -euo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_ROOT="${DOTFILES_DIR}/home"
+LIVE_ROOT="${HOME}"
+
+if [ ! -d "${SRC_ROOT}" ]; then
+  echo "No tracked files under ${SRC_ROOT} — nothing to capture."
+  exit 0
+fi
+
+updated=0
+unchanged=0
+missing=0
+
+while IFS= read -r -d '' tracked; do
+  rel="${tracked#"${SRC_ROOT}"/}"
+  live="${LIVE_ROOT}/${rel}"
+
+  if [ ! -f "${live}" ]; then
+    echo "missing ${rel} (not present on this machine)"
+    missing=$((missing + 1))
+    continue
+  fi
+
+  if cmp -s "${live}" "${tracked}"; then
+    unchanged=$((unchanged + 1))
+    continue
+  fi
+
+  cp "${live}" "${tracked}"
+  updated=$((updated + 1))
+  echo "capture ${rel}"
+done < <(find "${SRC_ROOT}" -type f -print0)
+
+echo "done: ${updated} updated, ${unchanged} unchanged, ${missing} missing"
+if [ "${updated}" -gt 0 ]; then
+  echo "review with 'git diff', then commit and open a PR."
+fi

--- a/dotfiles/home/.config/alacritty/alacritty-aurora.toml
+++ b/dotfiles/home/.config/alacritty/alacritty-aurora.toml
@@ -1,0 +1,238 @@
+# ❄ ✦ alacritty: aurora borealis ✦ ❄
+# Deep arctic night with shimmering aurora highlights.
+# Sister config to alacritty.toml (synthwave). Swap with:
+#   alacritty --config-file ~/.config/alacritty/alacritty-aurora.toml
+# or `mv` it over the default to make it permanent.
+
+[general]
+live_config_reload = true
+# Always open new windows in $HOME, not the spawning window's cwd.
+working_directory = "/home/cpitzi"
+
+[env]
+TERM = "alacritty"
+COLORTERM = "truecolor"
+
+# ─── window ──────────────────────────────────────────────────────────────
+[window]
+opacity = 0.93
+blur = true
+decorations = "full"
+dynamic_title = true
+dynamic_padding = false
+startup_mode = "Maximized"
+title = "✦ aurora ✦"
+
+[window.padding]
+x = 20
+y = 16
+
+[window.class]
+instance = "Alacritty"
+general  = "AlacrittyAurora"
+
+# ─── scrolling ───────────────────────────────────────────────────────────
+[scrolling]
+history = 100000
+multiplier = 4
+
+# ─── font ────────────────────────────────────────────────────────────────
+[font]
+size = 13.0
+builtin_box_drawing = true
+
+[font.normal]
+family = "JetBrainsMono Nerd Font"
+style  = "Light"
+
+[font.bold]
+family = "JetBrainsMono Nerd Font"
+style  = "SemiBold"
+
+[font.italic]
+family = "JetBrainsMono Nerd Font"
+style  = "Light Italic"
+
+[font.bold_italic]
+family = "JetBrainsMono Nerd Font"
+style  = "SemiBold Italic"
+
+[font.offset]
+x = 0
+y = 2
+
+# ─── cursor ──────────────────────────────────────────────────────────────
+[cursor]
+unfocused_hollow = true
+thickness = 0.25
+
+[cursor.style]
+shape    = "Underline"
+blinking = "On"
+
+[cursor.vi_mode_style]
+shape    = "Block"
+blinking = "Off"
+
+# ─── bell: soft twilight pulse ───────────────────────────────────────────
+[bell]
+animation = "EaseOutSine"
+duration  = 90
+color     = "#1a2050"   # just a breath above the bg — visible but gentle
+
+# ─── mouse / selection ───────────────────────────────────────────────────
+[mouse]
+hide_when_typing = true
+
+[[mouse.bindings]]
+mouse  = "Middle"
+action = "PasteSelection"
+
+[selection]
+save_to_clipboard      = true
+semantic_escape_chars  = ",│`|:\"' ()[]{}<>\t"
+
+# ─── colors: aurora borealis ─────────────────────────────────────────────
+[colors]
+draw_bold_text_with_bright_colors = true
+transparent_background_colors     = true
+
+[colors.primary]
+background        = "#050817"   # void / night sky
+foreground        = "#dbe9ff"   # moonlight on snow
+dim_foreground    = "#7a8aab"
+bright_foreground = "#ffffff"
+
+[colors.cursor]
+text   = "#050817"
+cursor = "#7df9ff"   # glacier cyan
+
+[colors.vi_mode_cursor]
+text   = "#050817"
+cursor = "#00ff9c"   # aurora green
+
+[colors.search.matches]
+foreground = "#050817"
+background = "#fff394"   # starlight
+
+[colors.search.focused_match]
+foreground = "#050817"
+background = "#00ff9c"
+
+[colors.footer_bar]
+foreground = "#dbe9ff"
+background = "#11183a"
+
+[colors.hints.start]
+foreground = "#050817"
+background = "#fff394"
+
+[colors.hints.end]
+foreground = "#050817"
+background = "#7df9ff"
+
+[colors.line_indicator]
+foreground = "None"
+background = "None"
+
+[colors.selection]
+text       = "#050817"
+background = "#9b6dff"   # twilight purple
+
+# normal: aurora palette
+[colors.normal]
+black   = "#0a0e27"
+red     = "#ff5c8a"   # rose dawn
+green   = "#00ff9c"   # aurora green
+yellow  = "#fff394"   # starlight
+blue    = "#5e9eff"   # ice blue
+magenta = "#c779ff"   # twilight purple
+cyan    = "#7df9ff"   # glacier
+white   = "#dbe9ff"   # moonlight
+
+# bright: cranked-up aurora intensity
+[colors.bright]
+black   = "#1a2050"
+red     = "#ff85a8"
+green   = "#7affc8"
+yellow  = "#fff9c2"
+blue    = "#8fc2ff"
+magenta = "#dba6ff"
+cyan    = "#b2fbff"
+white   = "#ffffff"
+
+[colors.dim]
+black   = "#02040d"
+red     = "#a83a5c"
+green   = "#00a868"
+yellow  = "#a8975f"
+blue    = "#3e6aa8"
+magenta = "#824da8"
+cyan    = "#52a3a8"
+white   = "#8a96b3"
+
+# indexed accents for prompt themes / starship modules
+[[colors.indexed_colors]]
+index = 16
+color = "#ff9e64"   # ember (warning)
+
+[[colors.indexed_colors]]
+index = 17
+color = "#00d4aa"   # mint (success)
+
+# ─── hints: click URLs ───────────────────────────────────────────────────
+[[hints.enabled]]
+command         = "xdg-open"
+hyperlinks      = true
+post_processing = true
+persist         = false
+mouse           = { enabled = true, mods = "None" }
+binding         = { key = "U", mods = "Control|Shift" }
+regex           = '(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file:|git://|ssh:|ftp://)[^<>"\s{-}\^⟨⟩`]+'
+
+# Hint: copy a hex color you see in the buffer
+[[hints.enabled]]
+command   = { program = "sh", args = ["-c", "printf '%s' \"$1\" | xclip -selection clipboard", "_"] }
+hyperlinks = false
+persist    = false
+mouse      = { enabled = false }
+binding    = { key = "H", mods = "Control|Shift" }
+regex      = '#(?:[0-9a-fA-F]{3}){1,2}\b'
+
+# ─── keybindings ─────────────────────────────────────────────────────────
+[keyboard]
+bindings = [
+  # font size
+  { key = "Equals", mods = "Control",          action = "IncreaseFontSize"  },
+  { key = "Plus",   mods = "Control",          action = "IncreaseFontSize"  },
+  { key = "Minus",  mods = "Control",          action = "DecreaseFontSize"  },
+  { key = "Key0",   mods = "Control",          action = "ResetFontSize"     },
+
+  # clipboard
+  { key = "C",      mods = "Control|Shift",    action = "Copy"              },
+  { key = "V",      mods = "Control|Shift",    action = "Paste"             },
+  { key = "Insert", mods = "Shift",            action = "PasteSelection"    },
+
+  # search
+  { key = "F",      mods = "Control|Shift",    action = "SearchForward"     },
+  { key = "B",      mods = "Control|Shift",    action = "SearchBackward"    },
+
+  # vi mode + scrollback
+  { key = "Space",  mods = "Control|Shift",    action = "ToggleViMode"      },
+  { key = "PageUp",                            action = "ScrollPageUp",   mode = "~Alt" },
+  { key = "PageDown",                          action = "ScrollPageDown", mode = "~Alt" },
+  { key = "Home",   mods = "Shift",            action = "ScrollToTop"       },
+  { key = "End",    mods = "Shift",            action = "ScrollToBottom"    },
+  { key = "K",      mods = "Control|Shift",    action = "ClearHistory"      },
+  { key = "L",      mods = "Control",          chars  = "\f"                },
+
+  # window
+  { key = "F11",                               action = "ToggleFullscreen"  },
+  { key = "Return", mods = "Alt",              action = "ToggleFullscreen"  },
+  { key = "N",      mods = "Control|Shift",    action = "CreateNewWindow"   },
+
+  # opacity (dim toward void) — nice for ambient mode
+  # opacity (dim toward void) — nice for ambient mode
+  { key = "BracketLeft",  mods = "Control|Shift", action = "DecreaseOpacity" },
+  { key = "BracketRight", mods = "Control|Shift", action = "IncreaseOpacity" },
+]

--- a/dotfiles/home/.config/alacritty/alacritty-ember.toml
+++ b/dotfiles/home/.config/alacritty/alacritty-ember.toml
@@ -1,0 +1,238 @@
+# ░▒▓█ alacritty: ember · warm low-glare █▓▒░
+# Warm amber/terracotta palette, Cascadia Code, dimmed foreground — built for
+# low eye-strain. This is the saved profile; it's also the current default
+# (mirrored into alacritty.toml). Swap back temporarily with:
+#   alacritty --config-file ~/.config/alacritty/alacritty-ember.toml
+# To make a DIFFERENT profile the default: cp that file over alacritty.toml.
+
+[general]
+live_config_reload = true
+# Always open new windows in $HOME, not the spawning window's cwd.
+working_directory = "/home/cpitzi"
+
+[env]
+TERM = "alacritty"
+COLORTERM = "truecolor"
+
+# ─── window ──────────────────────────────────────────────────────────────
+[window]
+opacity = 0.94
+blur = true
+decorations = "full"
+dynamic_title = true
+dynamic_padding = true
+startup_mode = "Windowed"
+title = "▓▒░ ember ░▒▓"
+
+[window.dimensions]
+columns = 140
+lines = 38
+
+[window.padding]
+x = 14
+y = 12
+
+# ─── scrolling ───────────────────────────────────────────────────────────
+[scrolling]
+history = 50000
+multiplier = 5
+
+# ─── font ────────────────────────────────────────────────────────────────
+# Sans-serif (Cascadia Code — crisp sans w/ cursive italics). At ~/.local/share/fonts.
+# Swap-in alternatives (already installed — just change the family below):
+#   • "Maple Mono NF"           — rounded humanist sans
+#   • "JetBrainsMono Nerd Font" — previous default, geometric sans
+# Falls back to system monospace if the family is missing.
+[font]
+size = 13.0
+builtin_box_drawing = true
+
+[font.normal]
+family = "CaskaydiaCove Nerd Font"
+style = "Regular"
+
+[font.bold]
+family = "CaskaydiaCove Nerd Font"
+style = "Bold"
+
+[font.italic]
+family = "CaskaydiaCove Nerd Font"
+style = "Italic"
+
+[font.bold_italic]
+family = "CaskaydiaCove Nerd Font"
+style = "Bold Italic"
+
+[font.offset]
+x = 0
+y = 1
+
+[font.glyph_offset]
+x = 0
+y = 0
+
+# ─── cursor ──────────────────────────────────────────────────────────────
+[cursor]
+unfocused_hollow = true
+thickness = 0.20
+
+[cursor.style]
+shape = "Beam"
+blinking = "Always"
+
+[cursor.vi_mode_style]
+shape = "Block"
+blinking = "Always"
+
+# ─── bell: soft violet pulse ─────────────────────────────────────────────
+[bell]
+animation = "EaseOutSine"
+duration = 90
+color = "#1b5d52"   # gentle breath above the purple bg
+
+# ─── mouse ───────────────────────────────────────────────────────────────
+[mouse]
+hide_when_typing = true
+
+[[mouse.bindings]]
+mouse = "Right"
+action = "PasteSelection"
+
+# ─── selection ───────────────────────────────────────────────────────────
+[selection]
+save_to_clipboard = true
+semantic_escape_chars = ",│`|:\"' ()[]{}<>\t"
+
+# ─── colors: lumen · 16° ──────────────────────────────────────────
+[colors]
+# Softened for low glare: bold no longer jumps to the bright (neon) palette.
+draw_bold_text_with_bright_colors = false
+
+[colors.primary]
+background = "#1d120d"         # warmer still
+foreground = "#c8a878"        # amber-cream, still dimmed for low glare
+dim_foreground = "#8f7a5c"
+bright_foreground = "#ddc48f"
+
+[colors.cursor]
+text   = "#1d120d"
+cursor = "#d69b50"
+
+[colors.vi_mode_cursor]
+text   = "#1d120d"
+cursor = "#aeb35f"
+
+[colors.search.matches]
+foreground = "#1d120d"
+background = "#b88560"
+
+[colors.search.focused_match]
+foreground = "#1d120d"
+background = "#d69b50"
+
+[colors.footer_bar]
+foreground = "#c8a878"
+background = "#3a2519"
+
+[colors.hints.start]
+foreground = "#1d120d"
+background = "#b88560"
+
+[colors.hints.end]
+foreground = "#1d120d"
+background = "#93b187"
+
+[colors.line_indicator]
+foreground = "None"
+background = "None"
+
+[colors.selection]
+text       = "CellBackground"
+background = "#6e5347"
+
+# normal — warm, muted (amber / olive / terracotta), low glare
+[colors.normal]
+black   = "#473027"
+red     = "#d67152"
+green   = "#aeb35f"
+yellow  = "#e0ad55"
+blue    = "#9a9fae"
+magenta = "#d18793"
+cyan    = "#93b187"
+white   = "#c2b08f"
+
+# bright — gently lifted warm tones, no longer neon
+[colors.bright]
+black   = "#785d50"
+red     = "#e38863"
+green   = "#c0c479"
+yellow  = "#ebc473"
+blue    = "#b1b2bf"
+magenta = "#e0a3a9"
+cyan    = "#acc6a9"
+white   = "#ddc48f"
+
+[colors.dim]
+black   = "#130b08"
+red     = "#991a0c"
+green   = "#0c9943"
+yellow  = "#99870c"
+blue    = "#0c1999"
+magenta = "#980c99"
+cyan    = "#0c6199"
+white   = "#719991"
+
+# indexed accents for prompts / shell highlighting
+[[colors.indexed_colors]]
+index = 16
+color = "#e0ad55"
+
+[[colors.indexed_colors]]
+index = 17
+color = "#93b187"
+
+# ─── hints: click URLs ───────────────────────────────────────────────────
+[[hints.enabled]]
+command         = "xdg-open"
+hyperlinks      = true
+post_processing = true
+persist         = false
+mouse           = { enabled = true, mods = "None" }
+binding         = { key = "U", mods = "Control|Shift" }
+regex = '(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file:|git://|ssh:|ftp://)[^<>"\s{-}\^⟨⟩`]+'
+
+# ─── keybindings ─────────────────────────────────────────────────────────
+[keyboard]
+bindings = [
+  # font size: ctrl + / - / 0
+  { key = "Equals", mods = "Control",          action = "IncreaseFontSize" },
+  { key = "Plus",   mods = "Control",          action = "IncreaseFontSize" },
+  { key = "Minus",  mods = "Control",          action = "DecreaseFontSize" },
+  { key = "Key0",   mods = "Control",          action = "ResetFontSize"    },
+
+  # clipboard
+  { key = "C",      mods = "Control|Shift",    action = "Copy"             },
+  { key = "V",      mods = "Control|Shift",    action = "Paste"            },
+  { key = "Insert", mods = "Shift",            action = "PasteSelection"   },
+
+  # search
+  { key = "F",      mods = "Control|Shift",    action = "SearchForward"    },
+  { key = "B",      mods = "Control|Shift",    action = "SearchBackward"   },
+
+  # vi mode + scrollback nav
+  { key = "Space",  mods = "Control|Shift",    action = "ToggleViMode"     },
+  { key = "PageUp",                            action = "ScrollPageUp",   mode = "~Alt" },
+  { key = "PageDown",                          action = "ScrollPageDown", mode = "~Alt" },
+  { key = "Home",   mods = "Shift",            action = "ScrollToTop"      },
+  { key = "End",    mods = "Shift",            action = "ScrollToBottom"   },
+
+  # window toys
+  { key = "F11",                               action = "ToggleFullscreen" },
+  { key = "N",      mods = "Control|Shift",    action = "CreateNewWindow"  },
+  { key = "Return", mods = "Alt",              action = "ToggleFullscreen" },
+  { key = "Return", mods = "Shift",            chars  = "\n"         },
+
+  # clear scrollback + screen
+  { key = "K",      mods = "Control|Shift",    action = "ClearHistory"     },
+  { key = "L",      mods = "Control",          chars  = "\f"               },
+]

--- a/dotfiles/home/.config/alacritty/alacritty.toml
+++ b/dotfiles/home/.config/alacritty/alacritty.toml
@@ -1,0 +1,235 @@
+# ░▒▓█ alacritty: ember (default) · warm low-glare █▓▒░
+# This is the active default. Canonical copy: alacritty-ember.toml.
+# Edit there and `cp` over this, or edit here — keep the two in sync.
+
+[general]
+live_config_reload = true
+# Always open new windows in $HOME, not the spawning window's cwd.
+working_directory = "/home/cpitzi"
+
+[env]
+TERM = "alacritty"
+COLORTERM = "truecolor"
+
+# ─── window ──────────────────────────────────────────────────────────────
+[window]
+opacity = 0.94
+blur = true
+decorations = "full"
+dynamic_title = true
+dynamic_padding = true
+startup_mode = "Windowed"
+title = "▓▒░ ember ░▒▓"
+
+[window.dimensions]
+columns = 140
+lines = 38
+
+[window.padding]
+x = 14
+y = 12
+
+# ─── scrolling ───────────────────────────────────────────────────────────
+[scrolling]
+history = 50000
+multiplier = 5
+
+# ─── font ────────────────────────────────────────────────────────────────
+# Sans-serif (Cascadia Code — crisp sans w/ cursive italics). At ~/.local/share/fonts.
+# Swap-in alternatives (already installed — just change the family below):
+#   • "Maple Mono NF"           — rounded humanist sans
+#   • "JetBrainsMono Nerd Font" — previous default, geometric sans
+# Falls back to system monospace if the family is missing.
+[font]
+size = 13.0
+builtin_box_drawing = true
+
+[font.normal]
+family = "CaskaydiaCove Nerd Font"
+style = "Regular"
+
+[font.bold]
+family = "CaskaydiaCove Nerd Font"
+style = "Bold"
+
+[font.italic]
+family = "CaskaydiaCove Nerd Font"
+style = "Italic"
+
+[font.bold_italic]
+family = "CaskaydiaCove Nerd Font"
+style = "Bold Italic"
+
+[font.offset]
+x = 0
+y = 1
+
+[font.glyph_offset]
+x = 0
+y = 0
+
+# ─── cursor ──────────────────────────────────────────────────────────────
+[cursor]
+unfocused_hollow = true
+thickness = 0.20
+
+[cursor.style]
+shape = "Beam"
+blinking = "Always"
+
+[cursor.vi_mode_style]
+shape = "Block"
+blinking = "Always"
+
+# ─── bell: soft violet pulse ─────────────────────────────────────────────
+[bell]
+animation = "EaseOutSine"
+duration = 90
+color = "#1b5d52"   # gentle breath above the purple bg
+
+# ─── mouse ───────────────────────────────────────────────────────────────
+[mouse]
+hide_when_typing = true
+
+[[mouse.bindings]]
+mouse = "Right"
+action = "PasteSelection"
+
+# ─── selection ───────────────────────────────────────────────────────────
+[selection]
+save_to_clipboard = true
+semantic_escape_chars = ",│`|:\"' ()[]{}<>\t"
+
+# ─── colors: lumen · 16° ──────────────────────────────────────────
+[colors]
+# Softened for low glare: bold no longer jumps to the bright (neon) palette.
+draw_bold_text_with_bright_colors = false
+
+[colors.primary]
+background = "#1d120d"         # warmer still
+foreground = "#c8a878"        # amber-cream, still dimmed for low glare
+dim_foreground = "#8f7a5c"
+bright_foreground = "#ddc48f"
+
+[colors.cursor]
+text   = "#1d120d"
+cursor = "#d69b50"
+
+[colors.vi_mode_cursor]
+text   = "#1d120d"
+cursor = "#aeb35f"
+
+[colors.search.matches]
+foreground = "#1d120d"
+background = "#b88560"
+
+[colors.search.focused_match]
+foreground = "#1d120d"
+background = "#d69b50"
+
+[colors.footer_bar]
+foreground = "#c8a878"
+background = "#3a2519"
+
+[colors.hints.start]
+foreground = "#1d120d"
+background = "#b88560"
+
+[colors.hints.end]
+foreground = "#1d120d"
+background = "#93b187"
+
+[colors.line_indicator]
+foreground = "None"
+background = "None"
+
+[colors.selection]
+text       = "CellBackground"
+background = "#6e5347"
+
+# normal — warm, muted (amber / olive / terracotta), low glare
+[colors.normal]
+black   = "#473027"
+red     = "#d67152"
+green   = "#aeb35f"
+yellow  = "#e0ad55"
+blue    = "#9a9fae"
+magenta = "#d18793"
+cyan    = "#93b187"
+white   = "#c2b08f"
+
+# bright — gently lifted warm tones, no longer neon
+[colors.bright]
+black   = "#785d50"
+red     = "#e38863"
+green   = "#c0c479"
+yellow  = "#ebc473"
+blue    = "#b1b2bf"
+magenta = "#e0a3a9"
+cyan    = "#acc6a9"
+white   = "#ddc48f"
+
+[colors.dim]
+black   = "#130b08"
+red     = "#991a0c"
+green   = "#0c9943"
+yellow  = "#99870c"
+blue    = "#0c1999"
+magenta = "#980c99"
+cyan    = "#0c6199"
+white   = "#719991"
+
+# indexed accents for prompts / shell highlighting
+[[colors.indexed_colors]]
+index = 16
+color = "#e0ad55"
+
+[[colors.indexed_colors]]
+index = 17
+color = "#93b187"
+
+# ─── hints: click URLs ───────────────────────────────────────────────────
+[[hints.enabled]]
+command         = "xdg-open"
+hyperlinks      = true
+post_processing = true
+persist         = false
+mouse           = { enabled = true, mods = "None" }
+binding         = { key = "U", mods = "Control|Shift" }
+regex = '(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file:|git://|ssh:|ftp://)[^<>"\s{-}\^⟨⟩`]+'
+
+# ─── keybindings ─────────────────────────────────────────────────────────
+[keyboard]
+bindings = [
+  # font size: ctrl + / - / 0
+  { key = "Equals", mods = "Control",          action = "IncreaseFontSize" },
+  { key = "Plus",   mods = "Control",          action = "IncreaseFontSize" },
+  { key = "Minus",  mods = "Control",          action = "DecreaseFontSize" },
+  { key = "Key0",   mods = "Control",          action = "ResetFontSize"    },
+
+  # clipboard
+  { key = "C",      mods = "Control|Shift",    action = "Copy"             },
+  { key = "V",      mods = "Control|Shift",    action = "Paste"            },
+  { key = "Insert", mods = "Shift",            action = "PasteSelection"   },
+
+  # search
+  { key = "F",      mods = "Control|Shift",    action = "SearchForward"    },
+  { key = "B",      mods = "Control|Shift",    action = "SearchBackward"   },
+
+  # vi mode + scrollback nav
+  { key = "Space",  mods = "Control|Shift",    action = "ToggleViMode"     },
+  { key = "PageUp",                            action = "ScrollPageUp",   mode = "~Alt" },
+  { key = "PageDown",                          action = "ScrollPageDown", mode = "~Alt" },
+  { key = "Home",   mods = "Shift",            action = "ScrollToTop"      },
+  { key = "End",    mods = "Shift",            action = "ScrollToBottom"   },
+
+  # window toys
+  { key = "F11",                               action = "ToggleFullscreen" },
+  { key = "N",      mods = "Control|Shift",    action = "CreateNewWindow"  },
+  { key = "Return", mods = "Alt",              action = "ToggleFullscreen" },
+  { key = "Return", mods = "Shift",            chars  = "\n"         },
+
+  # clear scrollback + screen
+  { key = "K",      mods = "Control|Shift",    action = "ClearHistory"     },
+  { key = "L",      mods = "Control",          chars  = "\f"               },
+]

--- a/dotfiles/install.sh
+++ b/dotfiles/install.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# install.sh — deploy tracked dotfiles from this repo into $HOME.
+#
+# Every file under dotfiles/home/ maps to the same relative path under $HOME
+# (e.g. dotfiles/home/.config/alacritty/alacritty.toml -> ~/.config/alacritty/
+# alacritty.toml). This script copies each one into place.
+#
+# Idempotent: files already identical are skipped. An existing live file that
+# differs is backed up under ~/.dotfiles-backup/ before being overwritten, so
+# a deploy never silently clobbers local edits you haven't captured yet.
+#
+# Run after a fresh provision (or any time you want the repo's configs live):
+#   dotfiles/install.sh
+#
+set -euo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_ROOT="${DOTFILES_DIR}/home"
+DEST_ROOT="${HOME}"
+BACKUP_DIR="${DEST_ROOT}/.dotfiles-backup"
+
+if [ ! -d "${SRC_ROOT}" ]; then
+  echo "No tracked files under ${SRC_ROOT} — nothing to install."
+  exit 0
+fi
+
+installed=0
+skipped=0
+backed_up=0
+
+while IFS= read -r -d '' src; do
+  rel="${src#"${SRC_ROOT}"/}"
+  dest="${DEST_ROOT}/${rel}"
+
+  if [ -f "${dest}" ] && cmp -s "${src}" "${dest}"; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if [ -e "${dest}" ]; then
+    bdest="${BACKUP_DIR}/${rel}"
+    mkdir -p "$(dirname "${bdest}")"
+    cp -p "${dest}" "${bdest}"
+    backed_up=$((backed_up + 1))
+    echo "backup  ${rel} -> ${bdest#"${DEST_ROOT}"/}"
+  fi
+
+  mkdir -p "$(dirname "${dest}")"
+  cp "${src}" "${dest}"
+  installed=$((installed + 1))
+  echo "install ${rel}"
+done < <(find "${SRC_ROOT}" -type f -print0)
+
+echo "done: ${installed} installed, ${skipped} unchanged, ${backed_up} backed up"


### PR DESCRIPTION
## Origin

Chris had just had Claude fix alacritty so new windows open in `$HOME`
instead of inheriting the spawning window's directory. He then asked for a
directory under workstation-bootstrap to start capturing local configs like
that one, and to push it out. The goal: keep hand-tuned local configs under
version control so they survive a machine rebuild, rather than re-tuning them
from scratch each time.

## What changed

New top-level `dotfiles/` directory:

- **`home/`** mirrors `$HOME` — a file's path under `home/` is its path under
  `$HOME`. The tree *is* the manifest; no separate mapping file to drift.
- **`install.sh`** — repo → `$HOME`. Idempotent; backs up any differing
  existing file to `~/.dotfiles-backup/` before overwriting. For a fresh
  provision or to make the repo's configs live.
- **`capture.sh`** — `$HOME` → repo. Refreshes already-tracked files from the
  live machine so a local edit becomes a reviewable diff. Only touches files
  already tracked — it won't slurp the whole home dir.
- **`README.md`** — layout, the install/capture workflow, how to add a new
  config, and the copy-vs-symlink rationale.

Seeded with `.config/alacritty/` (`alacritty.toml` + `ember`/`aurora` theme
variants), all three now pinning `working_directory` so new windows open in
`$HOME`.

## Design notes

- **Copy, not symlink** — keeps live files as real files so alacritty's
  in-place theme swap (`cp alacritty-aurora.toml alacritty.toml`) keeps
  working; a symlink would get clobbered. `capture.sh` is the trade-off for
  edits not flowing back automatically.
- **Not yet wired into `setup-*.sh`** — manual post-provision step for now;
  wiring it across all four scripts (per the keep-in-sync rule) is a sensible
  follow-up, called out in the README.

## Verification

- `shellcheck --severity=warning` clean on both scripts.
- `install.sh` and `capture.sh` both run as idempotent no-ops against the
  seeded files (`3 unchanged`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)