### PR TITLE
Wire dotfiles/install.sh into all four setup scripts

### DIFF
--- a/dotfiles/README.md
+++ b/dotfiles/README.md
@@ -61,11 +61,14 @@ That preserves in-place swapping — e.g. alacritty's
 clobber a symlink. The cost is that local edits don't flow back automatically;
 that's what `capture.sh` is for.
 
-## Not yet wired into `setup-*.sh`
+## Deployed by `setup-*.sh`
 
-The provisioning scripts don't call `install.sh` yet — for now it's a manual
-post-provision step. Wiring it in (across all four scripts, per the repo's
-keep-in-sync rule) is a sensible follow-up.
+All four provisioning scripts run `install.sh` automatically, as a non-fatal
+post-step right after they clone your repos (so the checkout that holds
+`install.sh` is already present). A fresh machine restores these configs with
+no manual step. The block is `-x`-guarded, so an older clone without
+`dotfiles/install.sh` simply skips it. Running `install.sh` by hand still
+works any time you want to re-deploy.
 
 ## What's tracked today
 

--- a/setup-crostini-lab.sh
+++ b/setup-crostini-lab.sh
@@ -1174,6 +1174,15 @@ if [[ -x "$WB_REPO/claude-cost-export/install.sh" ]]; then
   "$WB_REPO/claude-cost-export/install.sh" || warn "cost-export install failed (non-fatal — re-run later)"
 fi
 
+# --- Captured local dotfiles (alacritty, etc.) -----------------------------
+# Deploy hand-tuned configs tracked in dotfiles/ onto this machine. Idempotent;
+# backs up any differing existing file to ~/.dotfiles-backup/ before overwrite.
+# The repo clone above provides install.sh; non-fatal if it's an older clone.
+if [[ -x "$WB_REPO/dotfiles/install.sh" ]]; then
+  section "Local config files (dotfiles)"
+  "$WB_REPO/dotfiles/install.sh" || warn "dotfiles install failed (non-fatal — re-run later)"
+fi
+
 # ============================================================================
 section "🎉 Setup Complete!"
 echo ""

--- a/setup-fedora-workstation.sh
+++ b/setup-fedora-workstation.sh
@@ -1319,6 +1319,15 @@ if [[ -x "$WB_REPO/claude-cost-export/install.sh" ]]; then
   "$WB_REPO/claude-cost-export/install.sh" || warn "cost-export install failed (non-fatal — re-run later)"
 fi
 
+# --- Captured local dotfiles (alacritty, etc.) -----------------------------
+# Deploy hand-tuned configs tracked in dotfiles/ onto this machine. Idempotent;
+# backs up any differing existing file to ~/.dotfiles-backup/ before overwrite.
+# The repo clone above provides install.sh; non-fatal if it's an older clone.
+if [[ -x "$WB_REPO/dotfiles/install.sh" ]]; then
+  section "Local config files (dotfiles)"
+  "$WB_REPO/dotfiles/install.sh" || warn "dotfiles install failed (non-fatal — re-run later)"
+fi
+
 # ============================================================================
 section "🎉 Setup Complete!"
 echo ""

--- a/setup-ubuntu-laptop.sh
+++ b/setup-ubuntu-laptop.sh
@@ -1217,6 +1217,15 @@ if [[ -x "$WB_REPO/claude-cost-export/install.sh" ]]; then
   "$WB_REPO/claude-cost-export/install.sh" || warn "cost-export install failed (non-fatal — re-run later)"
 fi
 
+# --- Captured local dotfiles (alacritty, etc.) -----------------------------
+# Deploy hand-tuned configs tracked in dotfiles/ onto this machine. Idempotent;
+# backs up any differing existing file to ~/.dotfiles-backup/ before overwrite.
+# The repo clone above provides install.sh; non-fatal if it's an older clone.
+if [[ -x "$WB_REPO/dotfiles/install.sh" ]]; then
+  section "Local config files (dotfiles)"
+  "$WB_REPO/dotfiles/install.sh" || warn "dotfiles install failed (non-fatal — re-run later)"
+fi
+
 # ============================================================================
 section "🎉 Setup Complete!"
 echo ""

--- a/setup-xubuntu-workstation.sh
+++ b/setup-xubuntu-workstation.sh
@@ -1188,6 +1188,15 @@ if [[ -x "$WB_REPO/claude-cost-export/install.sh" ]]; then
   "$WB_REPO/claude-cost-export/install.sh" || warn "cost-export install failed (non-fatal — re-run later)"
 fi
 
+# --- Captured local dotfiles (alacritty, etc.) -----------------------------
+# Deploy hand-tuned configs tracked in dotfiles/ onto this machine. Idempotent;
+# backs up any differing existing file to ~/.dotfiles-backup/ before overwrite.
+# The repo clone above provides install.sh; non-fatal if it's an older clone.
+if [[ -x "$WB_REPO/dotfiles/install.sh" ]]; then
+  section "Local config files (dotfiles)"
+  "$WB_REPO/dotfiles/install.sh" || warn "dotfiles install failed (non-fatal — re-run later)"
+fi
+
 # ============================================================================
 section "🎉 Setup Complete!"
 echo ""


### PR DESCRIPTION
## Origin

Chris had just added the `dotfiles/` capture directory (#63) with an
`install.sh` that deploys hand-tuned local configs (alacritty et al.) onto a
machine. He then asked to wire that installer into the provisioning scripts so
a freshly-provisioned or rebuilt machine restores those configs automatically,
without a manual post-provision step.

## What changed

Each of the four `setup-*.sh` scripts now runs `dotfiles/install.sh`
automatically, as a non-fatal post-step immediately after the existing
`claude-cost-export` deploy — i.e. after the repo-clone step that lands the
`workstation-bootstrap` checkout containing `install.sh`:

```bash
if [[ -x "$WB_REPO/dotfiles/install.sh" ]]; then
  section "Local config files (dotfiles)"
  "$WB_REPO/dotfiles/install.sh" || warn "dotfiles install failed (non-fatal — re-run later)"
fi
```

The block is **identical across all four scripts** (per the keep-in-sync rule)
and deliberately mirrors the adjacent `claude-cost-export` precedent:

- **`-x`-guarded** — an older clone without `dotfiles/install.sh` skips cleanly.
- **Reuses `$WB_REPO`** — already defined in the preceding "Installing Scripts"
  step; no new clone, no duplicated logic.
- **Non-fatal** — a deploy failure is a `warn`, never a hard `exit` mid-setup.
- **No step renumbering** — like cost-export it's an unnumbered sub-section, so
  `TOTAL_STEPS` and every existing `N/$TOTAL_STEPS` header are untouched.

`dotfiles/README.md` updated: the "Not yet wired into setup-*.sh" section
becomes "Deployed by setup-*.sh".

## Verification

- `shellcheck --severity=warning` clean on all four scripts.
- `bash -n` syntax check passes on all four.
- The inserted block is byte-identical across the four files (verified by grep).

## Note (not in scope here)

The captured alacritty config pins `working_directory = "/home/cpitzi"` (an
absolute path, because alacritty doesn't expand `~`). Auto-deploying it assumes
the target runs as user `cpitzi`. True for the homelab VMs and laptop; if a
future target uses a different username, that one value would need adjusting.
Flagging rather than fixing, since it's a property of the captured config, not
this wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)