### PR TITLE
Disable automated Claude PR review (manual-only trigger)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,14 +7,12 @@
 
 name: Claude Code Review
 
+# >>> DISABLED 2026-06-25: automated Claude PR review turned off fleet-wide.
+# Trigger changed from `pull_request` to manual `workflow_dispatch` only, so it
+# never auto-runs on PRs. The repo-specific review_prompt below is preserved.
+# To re-enable, restore the `on: pull_request` trigger (see git history).
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    paths-ignore:
-      - "*.md"
-      - "docs/**"
-      - "LICENSE"
-      - ".gitignore"
+  workflow_dispatch:
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Summary

Disables the automated Claude Code review that previously ran on every pull
request by switching the `claude-code-review.yml` workflow trigger from
`pull_request` to a manual `workflow_dispatch`. The workflow and this repo's
tailored `review_prompt` are retained, so the review can still be invoked on
demand and re-enabled later by restoring the `pull_request` trigger.

This is part of a fleet-wide change turning off automated Claude PR review
across the PitziLabs repositories. The Claude review was not a required status
check in any repository, so disabling it does not change merge gating; the
real CI checks are untouched.

## Notes

- Only the workflow trigger changed — the job definition and review prompt are
  preserved.
- The interactive `@claude` responder (`claude.yml`) is intentionally left
  active; this change only affects the automated review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
